### PR TITLE
fix missing DEFAULT_FEE_TOKEN

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -17,6 +17,7 @@ import {INonce} from "./interfaces/INonce.sol";
 library StdPrecompiles {
     address internal constant TIP_FEE_MANAGER_ADDRESS = 0xfeEC000000000000000000000000000000000000;
     address internal constant PATH_USD_ADDRESS = 0x20C0000000000000000000000000000000000000;
+    address internal constant DEFAULT_FEE_TOKEN_ADDRESS = PATH_USD_ADDRESS;
     address internal constant TIP403_REGISTRY_ADDRESS = 0x403c000000000000000000000000000000000000;
     address internal constant TIP20_FACTORY_ADDRESS = 0x20Fc000000000000000000000000000000000000;
     address internal constant TIP20_REWARDS_REGISTRY_ADDRESS = 0x2100000000000000000000000000000000000000;
@@ -27,6 +28,7 @@ library StdPrecompiles {
 
     IFeeManager internal constant TIP_FEE_MANAGER = IFeeManager(TIP_FEE_MANAGER_ADDRESS);
     ITIP20 internal constant PATH_USD = ITIP20(PATH_USD_ADDRESS);
+    ITIP20 internal constant DEFAULT_FEE_TOKEN = ITIP20(DEFAULT_FEE_TOKEN_ADDRESS);
     ITIP403Registry internal constant TIP403_REGISTRY = ITIP403Registry(TIP403_REGISTRY_ADDRESS);
     ITIP20Factory internal constant TIP20_FACTORY = ITIP20Factory(TIP20_FACTORY_ADDRESS);
     ITIP20RewardsRegistry internal constant TIP20_REWARDS_REGISTRY =


### PR DESCRIPTION
Currently breaks template generated by `forge init -n tempo`