### PR TITLE
chore: add nightly interface sync workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,48 @@
+name: update
+
+on:
+  schedule:
+    # Nightly at 00:00 UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run sync
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x scripts/sync.sh
+          scripts/sync.sh
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "chore: interface update"
+          title: "chore: interface update"
+          body: |
+            Automated nightly sync via `scripts/sync.sh`.
+
+            - Trigger: scheduled workflow
+            - Notes: PR is only created when there are file changes.
+          branch: chore/nightly-sync
+          delete-branch: true

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -22,7 +22,7 @@ function main () {
     log $GREEN "Syncing specifications"
 
     # Clone specs repo and copy interface specs
-    git clone --depth 1 git@github.com:tempoxyz/tempo.git specs
+    git clone --depth 1 https://github.com/tempoxyz/tempo.git specs
     cp -r specs/docs/specs/src/interfaces src
     rm -rf specs
 


### PR DESCRIPTION
To keep interfaces up to date