### PR TITLE
feat: add transaction builders and vm.executeTransaction binding

### DIFF
--- a/src/StdVm.sol
+++ b/src/StdVm.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title Minimal Vm interface for RLP encoding.
+interface VmRlp {
+    /// @notice RLP encodes a list of byte strings into an RLP list payload.
+    function toRlp(bytes[] calldata data) external pure returns (bytes memory);
+}
+
+/// @title Minimal Vm interface for transaction execution.
+interface VmExecuteTransaction {
+    /// @notice Executes an RLP-encoded transaction with full EVM semantics.
+    /// @dev Decodes using TempoTxEnvelope::decode() which auto-detects tx type.
+    /// @param rawTx The RLP-encoded transaction bytes.
+    /// @return The execution output bytes.
+    function executeTransaction(bytes calldata rawTx) external returns (bytes memory);
+}

--- a/src/tx/AccessListTypes.sol
+++ b/src/tx/AccessListTypes.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @notice An entry in an EIP-2930 access list.
+struct AccessListItem {
+    address target;
+    bytes32[] storageKeys;
+}

--- a/src/tx/Eip1559TransactionLib.sol
+++ b/src/tx/Eip1559TransactionLib.sol
@@ -5,7 +5,7 @@ import {VmRlp} from "../StdVm.sol";
 import {TxRlp} from "./TxRlp.sol";
 import {AccessListItem} from "./AccessListTypes.sol";
 
-/// @notice An EIP-1559 (type 2) transaction.
+/// @notice An EIP-1559 (type 2) Ethereum transaction.
 struct Eip1559Transaction {
     uint64 chainId;
     uint64 nonce;
@@ -18,7 +18,7 @@ struct Eip1559Transaction {
     AccessListItem[] accessList;
 }
 
-/// @title Builder and RLP encoder for EIP-1559 transactions.
+/// @title Builder and RLP encoder for EIP-1559 transactions (type 0x02).
 library Eip1559TransactionLib {
     using Eip1559TransactionLib for Eip1559Transaction;
 
@@ -26,7 +26,8 @@ library Eip1559TransactionLib {
     uint8 internal constant TX_TYPE = 0x02;
 
     /// @notice Creates a new EIP-1559 transaction with default values.
-    function create() internal pure returns (Eip1559Transaction memory tx_) {
+    function create() internal view returns (Eip1559Transaction memory tx_) {
+        tx_.chainId = uint64(block.chainid);
         tx_.gasLimit = 21000;
     }
 
@@ -82,7 +83,7 @@ library Eip1559TransactionLib {
         return self;
     }
 
-    /// @notice Sets the value to transfer.
+    /// @notice Sets the value to send.
     function withValue(Eip1559Transaction memory self, uint256 value)
         internal
         pure
@@ -92,7 +93,7 @@ library Eip1559TransactionLib {
         return self;
     }
 
-    /// @notice Sets the call data.
+    /// @notice Sets the calldata.
     function withData(Eip1559Transaction memory self, bytes memory data)
         internal
         pure
@@ -112,71 +113,69 @@ library Eip1559TransactionLib {
         return self;
     }
 
-    /// @notice RLP encodes the unsigned transaction with type prefix.
+    /// @notice RLP encodes the unsigned transaction with type prefix 0x02.
     /// @dev Format: 0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList])
-    function encode(Eip1559Transaction memory self, VmRlp vm) internal pure returns (bytes memory) {
+    function encode(Eip1559Transaction memory self, VmRlp) internal pure returns (bytes memory) {
         bytes[] memory fields = new bytes[](9);
-        fields[0] = TxRlp.encodeUint(self.chainId);
-        fields[1] = TxRlp.encodeUint(self.nonce);
-        fields[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
-        fields[3] = TxRlp.encodeUint(self.maxFeePerGas);
-        fields[4] = TxRlp.encodeUint(self.gasLimit);
-        fields[5] = TxRlp.encodeAddress(self.to);
-        fields[6] = TxRlp.encodeUint(self.value);
-        fields[7] = self.data;
-        fields[8] = encodeAccessList(vm, self.accessList);
 
-        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[4] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
+        fields[5] = TxRlp.encodeString(self.to == address(0) ? TxRlp.encodeNone() : TxRlp.encodeAddress(self.to));
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.value));
+        fields[7] = TxRlp.encodeString(self.data);
+        fields[8] = _encodeAccessList(self.accessList);
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
         return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
-    /// @notice RLP encodes the signed transaction with type prefix.
+    /// @notice RLP encodes the signed transaction with type prefix 0x02.
     /// @dev Format: 0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, yParity, r, s])
-    function encodeWithSignature(Eip1559Transaction memory self, VmRlp vm, uint8 yParity, bytes32 r, bytes32 s)
+    function encodeWithSignature(Eip1559Transaction memory self, VmRlp, uint8 v, bytes32 r, bytes32 s)
         internal
         pure
         returns (bytes memory)
     {
         bytes[] memory fields = new bytes[](12);
-        fields[0] = TxRlp.encodeUint(self.chainId);
-        fields[1] = TxRlp.encodeUint(self.nonce);
-        fields[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
-        fields[3] = TxRlp.encodeUint(self.maxFeePerGas);
-        fields[4] = TxRlp.encodeUint(self.gasLimit);
-        fields[5] = TxRlp.encodeAddress(self.to);
-        fields[6] = TxRlp.encodeUint(self.value);
-        fields[7] = self.data;
-        fields[8] = encodeAccessList(vm, self.accessList);
-        fields[9] = TxRlp.encodeUint(yParity);
-        fields[10] = TxRlp.encodeBytes32(r);
-        fields[11] = TxRlp.encodeBytes32(s);
 
-        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[4] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
+        fields[5] = TxRlp.encodeString(self.to == address(0) ? TxRlp.encodeNone() : TxRlp.encodeAddress(self.to));
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.value));
+        fields[7] = TxRlp.encodeString(self.data);
+        fields[8] = _encodeAccessList(self.accessList);
+
+        // yParity: 0 or 1 (v - 27)
+        uint8 yParity = v >= 27 ? v - 27 : v;
+        fields[9] = TxRlp.encodeString(TxRlp.encodeUint(yParity));
+        fields[10] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
+        fields[11] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
         return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
-    /// @notice Encodes an access list as RLP.
-    /// @dev Each item is encoded as [address, [storageKey1, storageKey2, ...]].
-    function encodeAccessList(VmRlp vm, AccessListItem[] memory list) internal pure returns (bytes memory) {
+    /// @notice Encodes the access list as an RLP list.
+    function _encodeAccessList(AccessListItem[] memory list) private pure returns (bytes memory) {
         bytes[] memory encodedItems = new bytes[](list.length);
-
         for (uint256 i = 0; i < list.length; i++) {
-            AccessListItem memory item = list[i];
-
-            // Encode storage keys as a list
-            bytes[] memory encodedKeys = new bytes[](item.storageKeys.length);
-            for (uint256 j = 0; j < item.storageKeys.length; j++) {
-                encodedKeys[j] = TxRlp.encodeBytes32Full(item.storageKeys[j]);
+            bytes[] memory keys = new bytes[](list[i].storageKeys.length);
+            for (uint256 j = 0; j < list[i].storageKeys.length; j++) {
+                keys[j] = TxRlp.encodeString(TxRlp.encodeBytes32Full(list[i].storageKeys[j]));
             }
-            bytes memory keysList = TxRlp.encodeList(vm, encodedKeys);
+            bytes memory keysList = TxRlp.encodeRawList(keys);
 
-            // Encode [address, [keys...]]
-            bytes[] memory tuple = new bytes[](2);
-            tuple[0] = TxRlp.encodeAddress(item.target);
-            tuple[1] = keysList;
-            encodedItems[i] = TxRlp.encodeList(vm, tuple);
+            bytes[] memory itemFields = new bytes[](2);
+            itemFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(list[i].target));
+            itemFields[1] = keysList;
+            encodedItems[i] = TxRlp.encodeRawList(itemFields);
         }
-
-        return TxRlp.encodeList(vm, encodedItems);
+        return TxRlp.encodeRawList(encodedItems);
     }
 }

--- a/src/tx/Eip1559TransactionLib.sol
+++ b/src/tx/Eip1559TransactionLib.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {VmRlp} from "../StdVm.sol";
+import {TxRlp} from "./TxRlp.sol";
+import {AccessListItem} from "./AccessListTypes.sol";
+
+/// @notice An EIP-1559 (type 2) transaction.
+struct Eip1559Transaction {
+    uint64 chainId;
+    uint64 nonce;
+    uint256 maxPriorityFeePerGas;
+    uint256 maxFeePerGas;
+    uint64 gasLimit;
+    address to;
+    uint256 value;
+    bytes data;
+    AccessListItem[] accessList;
+}
+
+/// @title Builder and RLP encoder for EIP-1559 transactions.
+library Eip1559TransactionLib {
+    using Eip1559TransactionLib for Eip1559Transaction;
+
+    /// @notice EIP-1559 transaction type prefix.
+    uint8 internal constant TX_TYPE = 0x02;
+
+    /// @notice Creates a new EIP-1559 transaction with default values.
+    function create() internal pure returns (Eip1559Transaction memory tx_) {
+        tx_.gasLimit = 21000;
+    }
+
+    /// @notice Sets the chain ID.
+    function withChainId(Eip1559Transaction memory self, uint64 chainId)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.chainId = chainId;
+        return self;
+    }
+
+    /// @notice Sets the nonce.
+    function withNonce(Eip1559Transaction memory self, uint64 nonce) internal pure returns (Eip1559Transaction memory) {
+        self.nonce = nonce;
+        return self;
+    }
+
+    /// @notice Sets the max priority fee per gas.
+    function withMaxPriorityFeePerGas(Eip1559Transaction memory self, uint256 fee)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.maxPriorityFeePerGas = fee;
+        return self;
+    }
+
+    /// @notice Sets the max fee per gas.
+    function withMaxFeePerGas(Eip1559Transaction memory self, uint256 fee)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.maxFeePerGas = fee;
+        return self;
+    }
+
+    /// @notice Sets the gas limit.
+    function withGasLimit(Eip1559Transaction memory self, uint64 gasLimit)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.gasLimit = gasLimit;
+        return self;
+    }
+
+    /// @notice Sets the recipient address.
+    function withTo(Eip1559Transaction memory self, address to) internal pure returns (Eip1559Transaction memory) {
+        self.to = to;
+        return self;
+    }
+
+    /// @notice Sets the value to transfer.
+    function withValue(Eip1559Transaction memory self, uint256 value)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.value = value;
+        return self;
+    }
+
+    /// @notice Sets the call data.
+    function withData(Eip1559Transaction memory self, bytes memory data)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.data = data;
+        return self;
+    }
+
+    /// @notice Sets the access list.
+    function withAccessList(Eip1559Transaction memory self, AccessListItem[] memory accessList)
+        internal
+        pure
+        returns (Eip1559Transaction memory)
+    {
+        self.accessList = accessList;
+        return self;
+    }
+
+    /// @notice RLP encodes the unsigned transaction with type prefix.
+    /// @dev Format: 0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList])
+    function encode(Eip1559Transaction memory self, VmRlp vm) internal pure returns (bytes memory) {
+        bytes[] memory fields = new bytes[](9);
+        fields[0] = TxRlp.encodeUint(self.chainId);
+        fields[1] = TxRlp.encodeUint(self.nonce);
+        fields[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
+        fields[3] = TxRlp.encodeUint(self.maxFeePerGas);
+        fields[4] = TxRlp.encodeUint(self.gasLimit);
+        fields[5] = TxRlp.encodeAddress(self.to);
+        fields[6] = TxRlp.encodeUint(self.value);
+        fields[7] = self.data;
+        fields[8] = encodeAccessList(vm, self.accessList);
+
+        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        return abi.encodePacked(TX_TYPE, rlpPayload);
+    }
+
+    /// @notice RLP encodes the signed transaction with type prefix.
+    /// @dev Format: 0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, yParity, r, s])
+    function encodeWithSignature(Eip1559Transaction memory self, VmRlp vm, uint8 yParity, bytes32 r, bytes32 s)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes[] memory fields = new bytes[](12);
+        fields[0] = TxRlp.encodeUint(self.chainId);
+        fields[1] = TxRlp.encodeUint(self.nonce);
+        fields[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
+        fields[3] = TxRlp.encodeUint(self.maxFeePerGas);
+        fields[4] = TxRlp.encodeUint(self.gasLimit);
+        fields[5] = TxRlp.encodeAddress(self.to);
+        fields[6] = TxRlp.encodeUint(self.value);
+        fields[7] = self.data;
+        fields[8] = encodeAccessList(vm, self.accessList);
+        fields[9] = TxRlp.encodeUint(yParity);
+        fields[10] = TxRlp.encodeBytes32(r);
+        fields[11] = TxRlp.encodeBytes32(s);
+
+        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        return abi.encodePacked(TX_TYPE, rlpPayload);
+    }
+
+    /// @notice Encodes an access list as RLP.
+    /// @dev Each item is encoded as [address, [storageKey1, storageKey2, ...]].
+    function encodeAccessList(VmRlp vm, AccessListItem[] memory list) internal pure returns (bytes memory) {
+        bytes[] memory encodedItems = new bytes[](list.length);
+
+        for (uint256 i = 0; i < list.length; i++) {
+            AccessListItem memory item = list[i];
+
+            // Encode storage keys as a list
+            bytes[] memory encodedKeys = new bytes[](item.storageKeys.length);
+            for (uint256 j = 0; j < item.storageKeys.length; j++) {
+                encodedKeys[j] = TxRlp.encodeBytes32Full(item.storageKeys[j]);
+            }
+            bytes memory keysList = TxRlp.encodeList(vm, encodedKeys);
+
+            // Encode [address, [keys...]]
+            bytes[] memory tuple = new bytes[](2);
+            tuple[0] = TxRlp.encodeAddress(item.target);
+            tuple[1] = keysList;
+            encodedItems[i] = TxRlp.encodeList(vm, tuple);
+        }
+
+        return TxRlp.encodeList(vm, encodedItems);
+    }
+}

--- a/src/tx/Eip7702TransactionLib.sol
+++ b/src/tx/Eip7702TransactionLib.sol
@@ -5,24 +5,17 @@ import {VmRlp} from "../StdVm.sol";
 import {TxRlp} from "./TxRlp.sol";
 import {AccessListItem} from "./AccessListTypes.sol";
 
-/// @notice Unsigned EIP-7702 authorization tuple.
-struct Authorization {
-    uint64 chainId;
-    address authority;
-    uint64 nonce;
-}
-
-/// @notice Signed EIP-7702 authorization tuple.
-struct SignedAuthorization {
-    uint64 chainId;
-    address authority;
+/// @notice An EIP-7702 authorization tuple.
+struct Eip7702Authorization {
+    uint256 chainId;
+    address codeAddress;
     uint64 nonce;
     uint8 yParity;
     bytes32 r;
     bytes32 s;
 }
 
-/// @notice EIP-7702 transaction (type 0x04).
+/// @notice An EIP-7702 (type 4) Ethereum transaction.
 struct Eip7702Transaction {
     uint64 chainId;
     uint64 nonce;
@@ -33,33 +26,23 @@ struct Eip7702Transaction {
     uint256 value;
     bytes data;
     AccessListItem[] accessList;
-    SignedAuthorization[] authorizationList;
+    Eip7702Authorization[] authorizationList;
 }
 
-/// @title Library for encoding unsigned authorizations.
-library AuthorizationLib {
-    /// @notice RLP encodes an unsigned authorization for signing.
-    /// @dev Signing hash is `keccak256(0x05 || encode(auth))`.
-    /// @param self The authorization to encode.
-    /// @param vm The Vm RLP interface.
-    /// @return The RLP-encoded authorization (no type prefix).
-    function encode(Authorization memory self, VmRlp vm) internal pure returns (bytes memory) {
-        bytes[] memory items = new bytes[](3);
-        items[0] = TxRlp.encodeUint(self.chainId);
-        items[1] = TxRlp.encodeAddress(self.authority);
-        items[2] = TxRlp.encodeUint(self.nonce);
-        return TxRlp.encodeList(vm, items);
-    }
-}
-
-/// @title Library for building and RLP-encoding EIP-7702 transactions.
+/// @title Builder and RLP encoder for EIP-7702 transactions (type 0x04).
 library Eip7702TransactionLib {
+    using Eip7702TransactionLib for Eip7702Transaction;
+
     /// @notice EIP-7702 transaction type prefix.
-    bytes1 internal constant TYPE_PREFIX = 0x04;
+    uint8 internal constant TX_TYPE = 0x04;
+
+    /// @notice EIP-7702 authorization magic for signing.
+    uint8 internal constant AUTH_MAGIC = 0x05;
 
     /// @notice Creates a new EIP-7702 transaction with default values.
-    function create() internal pure returns (Eip7702Transaction memory t) {
-        t.gasLimit = 21000;
+    function create() internal view returns (Eip7702Transaction memory tx_) {
+        tx_.chainId = uint64(block.chainid);
+        tx_.gasLimit = 21000;
     }
 
     /// @notice Sets the chain ID.
@@ -108,13 +91,13 @@ library Eip7702TransactionLib {
         return self;
     }
 
-    /// @notice Sets the destination address.
+    /// @notice Sets the recipient address.
     function withTo(Eip7702Transaction memory self, address to) internal pure returns (Eip7702Transaction memory) {
         self.to = to;
         return self;
     }
 
-    /// @notice Sets the value in wei.
+    /// @notice Sets the value to send.
     function withValue(Eip7702Transaction memory self, uint256 value)
         internal
         pure
@@ -145,7 +128,7 @@ library Eip7702TransactionLib {
     }
 
     /// @notice Sets the authorization list.
-    function withAuthorizationList(Eip7702Transaction memory self, SignedAuthorization[] memory authorizationList)
+    function withAuthorizationList(Eip7702Transaction memory self, Eip7702Authorization[] memory authorizationList)
         internal
         pure
         returns (Eip7702Transaction memory)
@@ -154,86 +137,102 @@ library Eip7702TransactionLib {
         return self;
     }
 
-    /// @notice RLP encodes the unsigned transaction with type prefix.
-    /// @param self The transaction to encode.
-    /// @param vm The Vm RLP interface.
-    /// @return The encoded transaction: `0x04 || RLP([fields...])`.
-    function encode(Eip7702Transaction memory self, VmRlp vm) internal pure returns (bytes memory) {
-        bytes[] memory items = new bytes[](10);
-        items[0] = TxRlp.encodeUint(self.chainId);
-        items[1] = TxRlp.encodeUint(self.nonce);
-        items[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
-        items[3] = TxRlp.encodeUint(self.maxFeePerGas);
-        items[4] = TxRlp.encodeUint(self.gasLimit);
-        items[5] = TxRlp.encodeAddress(self.to);
-        items[6] = TxRlp.encodeUint(self.value);
-        items[7] = self.data;
-        items[8] = encodeAccessList(vm, self.accessList);
-        items[9] = encodeAuthorizationList(vm, self.authorizationList);
+    /// @notice RLP encodes the unsigned transaction with type prefix 0x04.
+    /// @dev Format: 0x04 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, authorizationList])
+    function encode(Eip7702Transaction memory self, VmRlp) internal pure returns (bytes memory) {
+        bytes[] memory fields = new bytes[](10);
 
-        return abi.encodePacked(TYPE_PREFIX, TxRlp.encodeList(vm, items));
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[4] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
+        fields[5] = TxRlp.encodeString(self.to == address(0) ? TxRlp.encodeNone() : TxRlp.encodeAddress(self.to));
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.value));
+        fields[7] = TxRlp.encodeString(self.data);
+        fields[8] = _encodeAccessList(self.accessList);
+        fields[9] = _encodeAuthorizationList(self.authorizationList);
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
+        return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
-    /// @notice RLP encodes the signed transaction with type prefix.
-    /// @param self The transaction to encode.
-    /// @param vm The Vm RLP interface.
-    /// @param yParity The signature y-parity (0 or 1).
-    /// @param r The signature r value.
-    /// @param s The signature s value.
-    /// @return The encoded transaction: `0x04 || RLP([fields..., yParity, r, s])`.
-    function encodeWithSignature(Eip7702Transaction memory self, VmRlp vm, uint8 yParity, bytes32 r, bytes32 s)
+    /// @notice RLP encodes the signed transaction with type prefix 0x04.
+    /// @dev Format: 0x04 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, authorizationList, yParity, r, s])
+    function encodeWithSignature(Eip7702Transaction memory self, VmRlp, uint8 v, bytes32 r, bytes32 s)
         internal
         pure
         returns (bytes memory)
     {
-        bytes[] memory items = new bytes[](13);
-        items[0] = TxRlp.encodeUint(self.chainId);
-        items[1] = TxRlp.encodeUint(self.nonce);
-        items[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
-        items[3] = TxRlp.encodeUint(self.maxFeePerGas);
-        items[4] = TxRlp.encodeUint(self.gasLimit);
-        items[5] = TxRlp.encodeAddress(self.to);
-        items[6] = TxRlp.encodeUint(self.value);
-        items[7] = self.data;
-        items[8] = encodeAccessList(vm, self.accessList);
-        items[9] = encodeAuthorizationList(vm, self.authorizationList);
-        items[10] = TxRlp.encodeUint(yParity);
-        items[11] = TxRlp.encodeBytes32(r);
-        items[12] = TxRlp.encodeBytes32(s);
+        bytes[] memory fields = new bytes[](13);
 
-        return abi.encodePacked(TYPE_PREFIX, TxRlp.encodeList(vm, items));
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[4] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
+        fields[5] = TxRlp.encodeString(self.to == address(0) ? TxRlp.encodeNone() : TxRlp.encodeAddress(self.to));
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.value));
+        fields[7] = TxRlp.encodeString(self.data);
+        fields[8] = _encodeAccessList(self.accessList);
+        fields[9] = _encodeAuthorizationList(self.authorizationList);
+
+        uint8 yParity = v >= 27 ? v - 27 : v;
+        fields[10] = TxRlp.encodeString(TxRlp.encodeUint(yParity));
+        fields[11] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
+        fields[12] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
+        return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
-    /// @notice Encodes an access list as RLP.
-    function encodeAccessList(VmRlp vm, AccessListItem[] memory list) private pure returns (bytes memory) {
+    /// @notice Computes the authorization hash for signing.
+    /// @dev Hash: keccak256(0x05 || RLP([chainId, codeAddress, nonce]))
+    function computeAuthorizationHash(uint256 chainId, address codeAddress, uint64 authNonce)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes[] memory fields = new bytes[](3);
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeAddress(codeAddress));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(authNonce));
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
+        return keccak256(abi.encodePacked(AUTH_MAGIC, rlpPayload));
+    }
+
+    /// @notice Encodes the access list as an RLP list.
+    function _encodeAccessList(AccessListItem[] memory list) private pure returns (bytes memory) {
         bytes[] memory encodedItems = new bytes[](list.length);
         for (uint256 i = 0; i < list.length; i++) {
             bytes[] memory keys = new bytes[](list[i].storageKeys.length);
             for (uint256 j = 0; j < list[i].storageKeys.length; j++) {
-                keys[j] = TxRlp.encodeBytes32Full(list[i].storageKeys[j]);
+                keys[j] = TxRlp.encodeString(TxRlp.encodeBytes32Full(list[i].storageKeys[j]));
             }
+            bytes memory keysList = TxRlp.encodeRawList(keys);
 
-            bytes[] memory item = new bytes[](2);
-            item[0] = TxRlp.encodeAddress(list[i].target);
-            item[1] = TxRlp.encodeList(vm, keys);
-            encodedItems[i] = TxRlp.encodeList(vm, item);
+            bytes[] memory itemFields = new bytes[](2);
+            itemFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(list[i].target));
+            itemFields[1] = keysList;
+            encodedItems[i] = TxRlp.encodeRawList(itemFields);
         }
-        return TxRlp.encodeList(vm, encodedItems);
+        return TxRlp.encodeRawList(encodedItems);
     }
 
-    /// @notice Encodes an authorization list as RLP.
-    function encodeAuthorizationList(VmRlp vm, SignedAuthorization[] memory list) private pure returns (bytes memory) {
-        bytes[] memory encodedItems = new bytes[](list.length);
+    /// @notice Encodes the authorization list as an RLP list.
+    function _encodeAuthorizationList(Eip7702Authorization[] memory list) private pure returns (bytes memory) {
+        bytes[] memory encodedAuths = new bytes[](list.length);
         for (uint256 i = 0; i < list.length; i++) {
-            bytes[] memory item = new bytes[](6);
-            item[0] = TxRlp.encodeUint(list[i].chainId);
-            item[1] = TxRlp.encodeAddress(list[i].authority);
-            item[2] = TxRlp.encodeUint(list[i].nonce);
-            item[3] = TxRlp.encodeUint(list[i].yParity);
-            item[4] = TxRlp.encodeBytes32(list[i].r);
-            item[5] = TxRlp.encodeBytes32(list[i].s);
-            encodedItems[i] = TxRlp.encodeList(vm, item);
+            bytes[] memory authFields = new bytes[](6);
+            authFields[0] = TxRlp.encodeString(TxRlp.encodeUint(list[i].chainId));
+            authFields[1] = TxRlp.encodeString(TxRlp.encodeAddress(list[i].codeAddress));
+            authFields[2] = TxRlp.encodeString(TxRlp.encodeUint(list[i].nonce));
+            authFields[3] = TxRlp.encodeString(TxRlp.encodeUint(list[i].yParity));
+            authFields[4] = TxRlp.encodeString(TxRlp.encodeBytes32(list[i].r));
+            authFields[5] = TxRlp.encodeString(TxRlp.encodeBytes32(list[i].s));
+            encodedAuths[i] = TxRlp.encodeRawList(authFields);
         }
-        return TxRlp.encodeList(vm, encodedItems);
+        return TxRlp.encodeRawList(encodedAuths);
     }
 }

--- a/src/tx/Eip7702TransactionLib.sol
+++ b/src/tx/Eip7702TransactionLib.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {VmRlp} from "../StdVm.sol";
+import {TxRlp} from "./TxRlp.sol";
+import {AccessListItem} from "./AccessListTypes.sol";
+
+/// @notice Unsigned EIP-7702 authorization tuple.
+struct Authorization {
+    uint64 chainId;
+    address authority;
+    uint64 nonce;
+}
+
+/// @notice Signed EIP-7702 authorization tuple.
+struct SignedAuthorization {
+    uint64 chainId;
+    address authority;
+    uint64 nonce;
+    uint8 yParity;
+    bytes32 r;
+    bytes32 s;
+}
+
+/// @notice EIP-7702 transaction (type 0x04).
+struct Eip7702Transaction {
+    uint64 chainId;
+    uint64 nonce;
+    uint256 maxPriorityFeePerGas;
+    uint256 maxFeePerGas;
+    uint64 gasLimit;
+    address to;
+    uint256 value;
+    bytes data;
+    AccessListItem[] accessList;
+    SignedAuthorization[] authorizationList;
+}
+
+/// @title Library for encoding unsigned authorizations.
+library AuthorizationLib {
+    /// @notice RLP encodes an unsigned authorization for signing.
+    /// @dev Signing hash is `keccak256(0x05 || encode(auth))`.
+    /// @param self The authorization to encode.
+    /// @param vm The Vm RLP interface.
+    /// @return The RLP-encoded authorization (no type prefix).
+    function encode(Authorization memory self, VmRlp vm) internal pure returns (bytes memory) {
+        bytes[] memory items = new bytes[](3);
+        items[0] = TxRlp.encodeUint(self.chainId);
+        items[1] = TxRlp.encodeAddress(self.authority);
+        items[2] = TxRlp.encodeUint(self.nonce);
+        return TxRlp.encodeList(vm, items);
+    }
+}
+
+/// @title Library for building and RLP-encoding EIP-7702 transactions.
+library Eip7702TransactionLib {
+    /// @notice EIP-7702 transaction type prefix.
+    bytes1 internal constant TYPE_PREFIX = 0x04;
+
+    /// @notice Creates a new EIP-7702 transaction with default values.
+    function create() internal pure returns (Eip7702Transaction memory t) {
+        t.gasLimit = 21000;
+    }
+
+    /// @notice Sets the chain ID.
+    function withChainId(Eip7702Transaction memory self, uint64 chainId)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.chainId = chainId;
+        return self;
+    }
+
+    /// @notice Sets the nonce.
+    function withNonce(Eip7702Transaction memory self, uint64 nonce) internal pure returns (Eip7702Transaction memory) {
+        self.nonce = nonce;
+        return self;
+    }
+
+    /// @notice Sets the max priority fee per gas.
+    function withMaxPriorityFeePerGas(Eip7702Transaction memory self, uint256 fee)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.maxPriorityFeePerGas = fee;
+        return self;
+    }
+
+    /// @notice Sets the max fee per gas.
+    function withMaxFeePerGas(Eip7702Transaction memory self, uint256 fee)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.maxFeePerGas = fee;
+        return self;
+    }
+
+    /// @notice Sets the gas limit.
+    function withGasLimit(Eip7702Transaction memory self, uint64 gasLimit)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.gasLimit = gasLimit;
+        return self;
+    }
+
+    /// @notice Sets the destination address.
+    function withTo(Eip7702Transaction memory self, address to) internal pure returns (Eip7702Transaction memory) {
+        self.to = to;
+        return self;
+    }
+
+    /// @notice Sets the value in wei.
+    function withValue(Eip7702Transaction memory self, uint256 value)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.value = value;
+        return self;
+    }
+
+    /// @notice Sets the calldata.
+    function withData(Eip7702Transaction memory self, bytes memory data)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.data = data;
+        return self;
+    }
+
+    /// @notice Sets the access list.
+    function withAccessList(Eip7702Transaction memory self, AccessListItem[] memory accessList)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.accessList = accessList;
+        return self;
+    }
+
+    /// @notice Sets the authorization list.
+    function withAuthorizationList(Eip7702Transaction memory self, SignedAuthorization[] memory authorizationList)
+        internal
+        pure
+        returns (Eip7702Transaction memory)
+    {
+        self.authorizationList = authorizationList;
+        return self;
+    }
+
+    /// @notice RLP encodes the unsigned transaction with type prefix.
+    /// @param self The transaction to encode.
+    /// @param vm The Vm RLP interface.
+    /// @return The encoded transaction: `0x04 || RLP([fields...])`.
+    function encode(Eip7702Transaction memory self, VmRlp vm) internal pure returns (bytes memory) {
+        bytes[] memory items = new bytes[](10);
+        items[0] = TxRlp.encodeUint(self.chainId);
+        items[1] = TxRlp.encodeUint(self.nonce);
+        items[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
+        items[3] = TxRlp.encodeUint(self.maxFeePerGas);
+        items[4] = TxRlp.encodeUint(self.gasLimit);
+        items[5] = TxRlp.encodeAddress(self.to);
+        items[6] = TxRlp.encodeUint(self.value);
+        items[7] = self.data;
+        items[8] = encodeAccessList(vm, self.accessList);
+        items[9] = encodeAuthorizationList(vm, self.authorizationList);
+
+        return abi.encodePacked(TYPE_PREFIX, TxRlp.encodeList(vm, items));
+    }
+
+    /// @notice RLP encodes the signed transaction with type prefix.
+    /// @param self The transaction to encode.
+    /// @param vm The Vm RLP interface.
+    /// @param yParity The signature y-parity (0 or 1).
+    /// @param r The signature r value.
+    /// @param s The signature s value.
+    /// @return The encoded transaction: `0x04 || RLP([fields..., yParity, r, s])`.
+    function encodeWithSignature(Eip7702Transaction memory self, VmRlp vm, uint8 yParity, bytes32 r, bytes32 s)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes[] memory items = new bytes[](13);
+        items[0] = TxRlp.encodeUint(self.chainId);
+        items[1] = TxRlp.encodeUint(self.nonce);
+        items[2] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
+        items[3] = TxRlp.encodeUint(self.maxFeePerGas);
+        items[4] = TxRlp.encodeUint(self.gasLimit);
+        items[5] = TxRlp.encodeAddress(self.to);
+        items[6] = TxRlp.encodeUint(self.value);
+        items[7] = self.data;
+        items[8] = encodeAccessList(vm, self.accessList);
+        items[9] = encodeAuthorizationList(vm, self.authorizationList);
+        items[10] = TxRlp.encodeUint(yParity);
+        items[11] = TxRlp.encodeBytes32(r);
+        items[12] = TxRlp.encodeBytes32(s);
+
+        return abi.encodePacked(TYPE_PREFIX, TxRlp.encodeList(vm, items));
+    }
+
+    /// @notice Encodes an access list as RLP.
+    function encodeAccessList(VmRlp vm, AccessListItem[] memory list) private pure returns (bytes memory) {
+        bytes[] memory encodedItems = new bytes[](list.length);
+        for (uint256 i = 0; i < list.length; i++) {
+            bytes[] memory keys = new bytes[](list[i].storageKeys.length);
+            for (uint256 j = 0; j < list[i].storageKeys.length; j++) {
+                keys[j] = TxRlp.encodeBytes32Full(list[i].storageKeys[j]);
+            }
+
+            bytes[] memory item = new bytes[](2);
+            item[0] = TxRlp.encodeAddress(list[i].target);
+            item[1] = TxRlp.encodeList(vm, keys);
+            encodedItems[i] = TxRlp.encodeList(vm, item);
+        }
+        return TxRlp.encodeList(vm, encodedItems);
+    }
+
+    /// @notice Encodes an authorization list as RLP.
+    function encodeAuthorizationList(VmRlp vm, SignedAuthorization[] memory list) private pure returns (bytes memory) {
+        bytes[] memory encodedItems = new bytes[](list.length);
+        for (uint256 i = 0; i < list.length; i++) {
+            bytes[] memory item = new bytes[](6);
+            item[0] = TxRlp.encodeUint(list[i].chainId);
+            item[1] = TxRlp.encodeAddress(list[i].authority);
+            item[2] = TxRlp.encodeUint(list[i].nonce);
+            item[3] = TxRlp.encodeUint(list[i].yParity);
+            item[4] = TxRlp.encodeBytes32(list[i].r);
+            item[5] = TxRlp.encodeBytes32(list[i].s);
+            encodedItems[i] = TxRlp.encodeList(vm, item);
+        }
+        return TxRlp.encodeList(vm, encodedItems);
+    }
+}

--- a/src/tx/LegacyTransactionLib.sol
+++ b/src/tx/LegacyTransactionLib.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {VmRlp} from "../StdVm.sol";
+import {TxRlp} from "./TxRlp.sol";
+
+/// @notice A legacy (type 0) Ethereum transaction.
+struct LegacyTransaction {
+    uint64 nonce;
+    uint256 gasPrice;
+    uint64 gasLimit;
+    address to;
+    uint256 value;
+    bytes data;
+}
+
+/// @title Builder and RLP encoder for legacy Ethereum transactions.
+library LegacyTransactionLib {
+    using LegacyTransactionLib for LegacyTransaction;
+
+    /// @notice Creates a new legacy transaction with default values.
+    /// @dev Default gasLimit is 21000 (simple transfer).
+    function create() internal pure returns (LegacyTransaction memory) {
+        return LegacyTransaction({nonce: 0, gasPrice: 0, gasLimit: 21000, to: address(0), value: 0, data: ""});
+    }
+
+    /// @notice Sets the nonce.
+    function withNonce(LegacyTransaction memory self, uint64 nonce) internal pure returns (LegacyTransaction memory) {
+        self.nonce = nonce;
+        return self;
+    }
+
+    /// @notice Sets the gas price.
+    function withGasPrice(LegacyTransaction memory self, uint256 gasPrice)
+        internal
+        pure
+        returns (LegacyTransaction memory)
+    {
+        self.gasPrice = gasPrice;
+        return self;
+    }
+
+    /// @notice Sets the gas limit.
+    function withGasLimit(LegacyTransaction memory self, uint64 gasLimit)
+        internal
+        pure
+        returns (LegacyTransaction memory)
+    {
+        self.gasLimit = gasLimit;
+        return self;
+    }
+
+    /// @notice Sets the recipient address.
+    function withTo(LegacyTransaction memory self, address to) internal pure returns (LegacyTransaction memory) {
+        self.to = to;
+        return self;
+    }
+
+    /// @notice Sets the value to send.
+    function withValue(LegacyTransaction memory self, uint256 value) internal pure returns (LegacyTransaction memory) {
+        self.value = value;
+        return self;
+    }
+
+    /// @notice Sets the calldata.
+    function withData(LegacyTransaction memory self, bytes memory data)
+        internal
+        pure
+        returns (LegacyTransaction memory)
+    {
+        self.data = data;
+        return self;
+    }
+
+    /// @notice RLP encodes the unsigned transaction (6 fields).
+    /// @dev Legacy transactions have no type prefix.
+    function encode(LegacyTransaction memory self, VmRlp vm) internal pure returns (bytes memory) {
+        bytes[] memory items = new bytes[](6);
+        items[0] = TxRlp.encodeUint(self.nonce);
+        items[1] = TxRlp.encodeUint(self.gasPrice);
+        items[2] = TxRlp.encodeUint(self.gasLimit);
+        items[3] = self.to == address(0) ? TxRlp.encodeNone() : TxRlp.encodeAddress(self.to);
+        items[4] = TxRlp.encodeUint(self.value);
+        items[5] = self.data;
+
+        return TxRlp.encodeList(vm, items);
+    }
+
+    /// @notice RLP encodes the signed transaction (9 fields).
+    /// @dev Legacy transactions have no type prefix.
+    function encodeWithSignature(LegacyTransaction memory self, VmRlp vm, uint8 v, bytes32 r, bytes32 s)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes[] memory items = new bytes[](9);
+        items[0] = TxRlp.encodeUint(self.nonce);
+        items[1] = TxRlp.encodeUint(self.gasPrice);
+        items[2] = TxRlp.encodeUint(self.gasLimit);
+        items[3] = self.to == address(0) ? TxRlp.encodeNone() : TxRlp.encodeAddress(self.to);
+        items[4] = TxRlp.encodeUint(self.value);
+        items[5] = self.data;
+        items[6] = TxRlp.encodeUint(v);
+        items[7] = TxRlp.encodeBytes32(r);
+        items[8] = TxRlp.encodeBytes32(s);
+
+        return TxRlp.encodeList(vm, items);
+    }
+}

--- a/src/tx/TempoTransactionLib.sol
+++ b/src/tx/TempoTransactionLib.sol
@@ -209,12 +209,22 @@ library TempoTransactionLib {
         fields[5] = encodeAccessList(vm, self.accessList);
         fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
         fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
-        fields[8] = self.hasValidBefore ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore)) : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[9] = self.hasValidAfter ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter)) : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[10] = self.hasFeeToken ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken)) : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[11] = self.hasFeePayerSignature ? TxRlp.encodeString(self.feePayerSignature) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[8] = self.hasValidBefore
+            ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore))
+            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[9] = self.hasValidAfter
+            ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter))
+            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[10] = self.hasFeeToken
+            ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken))
+            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[11] = self.hasFeePayerSignature
+            ? TxRlp.encodeString(self.feePayerSignature)
+            : TxRlp.encodeString(TxRlp.encodeNone());
         fields[12] = encodeAuthorizationList(vm, self.authorizationList);
-        fields[13] = self.hasKeyAuthorization ? TxRlp.encodeString(self.keyAuthorization) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[13] = self.hasKeyAuthorization
+            ? TxRlp.encodeString(self.keyAuthorization)
+            : TxRlp.encodeString(TxRlp.encodeNone());
 
         bytes memory rlpPayload = TxRlp.encodeRawList(fields);
         return abi.encodePacked(bytes1(0x76), rlpPayload);
@@ -236,12 +246,22 @@ library TempoTransactionLib {
         fields[5] = encodeAccessList(vm, self.accessList);
         fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
         fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
-        fields[8] = self.hasValidBefore ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore)) : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[9] = self.hasValidAfter ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter)) : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[10] = self.hasFeeToken ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken)) : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[11] = self.hasFeePayerSignature ? TxRlp.encodeString(self.feePayerSignature) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[8] = self.hasValidBefore
+            ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore))
+            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[9] = self.hasValidAfter
+            ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter))
+            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[10] = self.hasFeeToken
+            ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken))
+            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[11] = self.hasFeePayerSignature
+            ? TxRlp.encodeString(self.feePayerSignature)
+            : TxRlp.encodeString(TxRlp.encodeNone());
         fields[12] = encodeAuthorizationList(vm, self.authorizationList);
-        fields[13] = self.hasKeyAuthorization ? TxRlp.encodeString(self.keyAuthorization) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[13] = self.hasKeyAuthorization
+            ? TxRlp.encodeString(self.keyAuthorization)
+            : TxRlp.encodeString(TxRlp.encodeNone());
         fields[14] = TxRlp.encodeString(TxRlp.encodeUint(v));
         fields[15] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
         fields[16] = TxRlp.encodeString(TxRlp.encodeBytes32(s));

--- a/src/tx/TempoTransactionLib.sol
+++ b/src/tx/TempoTransactionLib.sol
@@ -201,22 +201,22 @@ library TempoTransactionLib {
     function encode(TempoTransaction memory self, VmRlp vm) internal pure returns (bytes memory) {
         bytes[] memory fields = new bytes[](14);
 
-        fields[0] = TxRlp.encodeUint(self.chainId);
-        fields[1] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
-        fields[2] = TxRlp.encodeUint(self.maxFeePerGas);
-        fields[3] = TxRlp.encodeUint(self.gasLimit);
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
         fields[4] = encodeCalls(vm, self.calls);
         fields[5] = encodeAccessList(vm, self.accessList);
-        fields[6] = TxRlp.encodeUint(self.nonceKey);
-        fields[7] = TxRlp.encodeUint(self.nonce);
-        fields[8] = self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone();
-        fields[9] = self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone();
-        fields[10] = self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone();
-        fields[11] = self.hasFeePayerSignature ? self.feePayerSignature : TxRlp.encodeNone();
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
+        fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[8] = self.hasValidBefore ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore)) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[9] = self.hasValidAfter ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter)) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[10] = self.hasFeeToken ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken)) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[11] = self.hasFeePayerSignature ? TxRlp.encodeString(self.feePayerSignature) : TxRlp.encodeString(TxRlp.encodeNone());
         fields[12] = encodeAuthorizationList(vm, self.authorizationList);
-        fields[13] = self.hasKeyAuthorization ? self.keyAuthorization : TxRlp.encodeNone();
+        fields[13] = self.hasKeyAuthorization ? TxRlp.encodeString(self.keyAuthorization) : TxRlp.encodeString(TxRlp.encodeNone());
 
-        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
         return abi.encodePacked(bytes1(0x76), rlpPayload);
     }
 
@@ -228,70 +228,70 @@ library TempoTransactionLib {
     {
         bytes[] memory fields = new bytes[](17);
 
-        fields[0] = TxRlp.encodeUint(self.chainId);
-        fields[1] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
-        fields[2] = TxRlp.encodeUint(self.maxFeePerGas);
-        fields[3] = TxRlp.encodeUint(self.gasLimit);
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
         fields[4] = encodeCalls(vm, self.calls);
         fields[5] = encodeAccessList(vm, self.accessList);
-        fields[6] = TxRlp.encodeUint(self.nonceKey);
-        fields[7] = TxRlp.encodeUint(self.nonce);
-        fields[8] = self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone();
-        fields[9] = self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone();
-        fields[10] = self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone();
-        fields[11] = self.hasFeePayerSignature ? self.feePayerSignature : TxRlp.encodeNone();
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
+        fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[8] = self.hasValidBefore ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore)) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[9] = self.hasValidAfter ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter)) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[10] = self.hasFeeToken ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken)) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[11] = self.hasFeePayerSignature ? TxRlp.encodeString(self.feePayerSignature) : TxRlp.encodeString(TxRlp.encodeNone());
         fields[12] = encodeAuthorizationList(vm, self.authorizationList);
-        fields[13] = self.hasKeyAuthorization ? self.keyAuthorization : TxRlp.encodeNone();
-        fields[14] = TxRlp.encodeUint(v);
-        fields[15] = TxRlp.encodeBytes32(r);
-        fields[16] = TxRlp.encodeBytes32(s);
+        fields[13] = self.hasKeyAuthorization ? TxRlp.encodeString(self.keyAuthorization) : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[14] = TxRlp.encodeString(TxRlp.encodeUint(v));
+        fields[15] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
+        fields[16] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
 
-        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
         return abi.encodePacked(bytes1(0x76), rlpPayload);
     }
 
     /// @notice Encodes the calls array as an RLP list.
-    function encodeCalls(VmRlp vm, TempoCall[] memory calls) internal pure returns (bytes memory) {
+    function encodeCalls(VmRlp, TempoCall[] memory calls) internal pure returns (bytes memory) {
         bytes[] memory encodedCalls = new bytes[](calls.length);
         for (uint256 i = 0; i < calls.length; i++) {
             bytes[] memory callFields = new bytes[](3);
-            callFields[0] = TxRlp.encodeAddress(calls[i].to);
-            callFields[1] = TxRlp.encodeUint(calls[i].value);
-            callFields[2] = calls[i].data;
-            encodedCalls[i] = TxRlp.encodeList(vm, callFields);
+            callFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(calls[i].to));
+            callFields[1] = TxRlp.encodeString(TxRlp.encodeUint(calls[i].value));
+            callFields[2] = TxRlp.encodeString(calls[i].data);
+            encodedCalls[i] = TxRlp.encodeRawList(callFields);
         }
-        return TxRlp.encodeList(vm, encodedCalls);
+        return TxRlp.encodeRawList(encodedCalls);
     }
 
     /// @notice Encodes the access list as an RLP list.
-    function encodeAccessList(VmRlp vm, AccessListItem[] memory list) internal pure returns (bytes memory) {
+    function encodeAccessList(VmRlp, AccessListItem[] memory list) internal pure returns (bytes memory) {
         bytes[] memory encodedItems = new bytes[](list.length);
         for (uint256 i = 0; i < list.length; i++) {
             bytes[] memory keys = new bytes[](list[i].storageKeys.length);
             for (uint256 j = 0; j < list[i].storageKeys.length; j++) {
-                keys[j] = TxRlp.encodeBytes32Full(list[i].storageKeys[j]);
+                keys[j] = TxRlp.encodeString(TxRlp.encodeBytes32Full(list[i].storageKeys[j]));
             }
             bytes[] memory itemFields = new bytes[](2);
-            itemFields[0] = TxRlp.encodeAddress(list[i].target);
-            itemFields[1] = TxRlp.encodeList(vm, keys);
-            encodedItems[i] = TxRlp.encodeList(vm, itemFields);
+            itemFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(list[i].target));
+            itemFields[1] = TxRlp.encodeRawList(keys);
+            encodedItems[i] = TxRlp.encodeRawList(itemFields);
         }
-        return TxRlp.encodeList(vm, encodedItems);
+        return TxRlp.encodeRawList(encodedItems);
     }
 
     /// @notice Encodes the authorization list as an RLP list.
-    function encodeAuthorizationList(VmRlp vm, TempoAuthorization[] memory list) internal pure returns (bytes memory) {
+    function encodeAuthorizationList(VmRlp, TempoAuthorization[] memory list) internal pure returns (bytes memory) {
         bytes[] memory encodedAuths = new bytes[](list.length);
         for (uint256 i = 0; i < list.length; i++) {
             bytes[] memory authFields = new bytes[](6);
-            authFields[0] = TxRlp.encodeUint(list[i].chainId);
-            authFields[1] = TxRlp.encodeAddress(list[i].authority);
-            authFields[2] = TxRlp.encodeUint(list[i].nonce);
-            authFields[3] = TxRlp.encodeUint(list[i].yParity);
-            authFields[4] = TxRlp.encodeBytes32(list[i].r);
-            authFields[5] = TxRlp.encodeBytes32(list[i].s);
-            encodedAuths[i] = TxRlp.encodeList(vm, authFields);
+            authFields[0] = TxRlp.encodeString(TxRlp.encodeUint(list[i].chainId));
+            authFields[1] = TxRlp.encodeString(TxRlp.encodeAddress(list[i].authority));
+            authFields[2] = TxRlp.encodeString(TxRlp.encodeUint(list[i].nonce));
+            authFields[3] = TxRlp.encodeString(TxRlp.encodeUint(list[i].yParity));
+            authFields[4] = TxRlp.encodeString(TxRlp.encodeBytes32(list[i].r));
+            authFields[5] = TxRlp.encodeString(TxRlp.encodeBytes32(list[i].s));
+            encodedAuths[i] = TxRlp.encodeRawList(authFields);
         }
-        return TxRlp.encodeList(vm, encodedAuths);
+        return TxRlp.encodeRawList(encodedAuths);
     }
 }

--- a/src/tx/TempoTransactionLib.sol
+++ b/src/tx/TempoTransactionLib.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {VmRlp} from "../StdVm.sol";
+import {TxRlp} from "./TxRlp.sol";
+import {AccessListItem} from "./AccessListTypes.sol";
+
+/// @notice A single call in a Tempo transaction batch.
+struct TempoCall {
+    address to;
+    uint256 value;
+    bytes data;
+}
+
+/// @notice A signed authorization for Tempo transactions.
+struct TempoAuthorization {
+    uint256 chainId;
+    address authority;
+    uint64 nonce;
+    uint8 yParity;
+    bytes32 r;
+    bytes32 s;
+}
+
+/// @notice A Tempo transaction (type 0x76).
+struct TempoTransaction {
+    uint64 chainId;
+    uint256 maxPriorityFeePerGas;
+    uint256 maxFeePerGas;
+    uint64 gasLimit;
+    TempoCall[] calls;
+    AccessListItem[] accessList;
+    uint256 nonceKey;
+    uint64 nonce;
+    bool hasValidBefore;
+    uint64 validBefore;
+    bool hasValidAfter;
+    uint64 validAfter;
+    bool hasFeeToken;
+    address feeToken;
+    bool hasFeePayerSignature;
+    bytes feePayerSignature;
+    TempoAuthorization[] authorizationList;
+    bool hasKeyAuthorization;
+    bytes keyAuthorization;
+}
+
+/// @title Builder and RLP encoder for Tempo transactions (type 0x76).
+library TempoTransactionLib {
+    /// @notice Creates a new Tempo transaction with default values.
+    function create() internal pure returns (TempoTransaction memory tx_) {
+        tx_.gasLimit = 21000;
+    }
+
+    /// @notice Sets the chain ID.
+    function withChainId(TempoTransaction memory self, uint64 chainId) internal pure returns (TempoTransaction memory) {
+        self.chainId = chainId;
+        return self;
+    }
+
+    /// @notice Sets the max priority fee per gas.
+    function withMaxPriorityFeePerGas(TempoTransaction memory self, uint256 fee)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.maxPriorityFeePerGas = fee;
+        return self;
+    }
+
+    /// @notice Sets the max fee per gas.
+    function withMaxFeePerGas(TempoTransaction memory self, uint256 fee)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.maxFeePerGas = fee;
+        return self;
+    }
+
+    /// @notice Sets the gas limit.
+    function withGasLimit(TempoTransaction memory self, uint64 gasLimit)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.gasLimit = gasLimit;
+        return self;
+    }
+
+    /// @notice Sets the calls array.
+    function withCalls(TempoTransaction memory self, TempoCall[] memory calls)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.calls = calls;
+        return self;
+    }
+
+    /// @notice Convenience method to set a single call.
+    function withCall(TempoTransaction memory self, address to, uint256 value, bytes memory data)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        TempoCall[] memory calls = new TempoCall[](1);
+        calls[0] = TempoCall({to: to, value: value, data: data});
+        self.calls = calls;
+        return self;
+    }
+
+    /// @notice Sets the access list.
+    function withAccessList(TempoTransaction memory self, AccessListItem[] memory accessList)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.accessList = accessList;
+        return self;
+    }
+
+    /// @notice Sets the 2D nonce key.
+    function withNonceKey(TempoTransaction memory self, uint256 nonceKey)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.nonceKey = nonceKey;
+        return self;
+    }
+
+    /// @notice Sets the nonce.
+    function withNonce(TempoTransaction memory self, uint64 nonce) internal pure returns (TempoTransaction memory) {
+        self.nonce = nonce;
+        return self;
+    }
+
+    /// @notice Sets the validBefore timestamp.
+    function withValidBefore(TempoTransaction memory self, uint64 timestamp)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.hasValidBefore = true;
+        self.validBefore = timestamp;
+        return self;
+    }
+
+    /// @notice Sets the validAfter timestamp.
+    function withValidAfter(TempoTransaction memory self, uint64 timestamp)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.hasValidAfter = true;
+        self.validAfter = timestamp;
+        return self;
+    }
+
+    /// @notice Sets the fee token address.
+    function withFeeToken(TempoTransaction memory self, address token) internal pure returns (TempoTransaction memory) {
+        self.hasFeeToken = true;
+        self.feeToken = token;
+        return self;
+    }
+
+    /// @notice Sets the fee payer signature.
+    function withFeePayerSignature(TempoTransaction memory self, bytes memory signature)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.hasFeePayerSignature = true;
+        self.feePayerSignature = signature;
+        return self;
+    }
+
+    /// @notice Sets the authorization list.
+    function withAuthorizationList(TempoTransaction memory self, TempoAuthorization[] memory authorizationList)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.authorizationList = authorizationList;
+        return self;
+    }
+
+    /// @notice Sets the key authorization.
+    function withKeyAuthorization(TempoTransaction memory self, bytes memory keyAuthorization)
+        internal
+        pure
+        returns (TempoTransaction memory)
+    {
+        self.hasKeyAuthorization = true;
+        self.keyAuthorization = keyAuthorization;
+        return self;
+    }
+
+    /// @notice RLP encodes the unsigned transaction with type prefix 0x76.
+    function encode(TempoTransaction memory self, VmRlp vm) internal pure returns (bytes memory) {
+        bytes[] memory fields = new bytes[](14);
+
+        fields[0] = TxRlp.encodeUint(self.chainId);
+        fields[1] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
+        fields[2] = TxRlp.encodeUint(self.maxFeePerGas);
+        fields[3] = TxRlp.encodeUint(self.gasLimit);
+        fields[4] = encodeCalls(vm, self.calls);
+        fields[5] = encodeAccessList(vm, self.accessList);
+        fields[6] = TxRlp.encodeUint(self.nonceKey);
+        fields[7] = TxRlp.encodeUint(self.nonce);
+        fields[8] = self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone();
+        fields[9] = self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone();
+        fields[10] = self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone();
+        fields[11] = self.hasFeePayerSignature ? self.feePayerSignature : TxRlp.encodeNone();
+        fields[12] = encodeAuthorizationList(vm, self.authorizationList);
+        fields[13] = self.hasKeyAuthorization ? self.keyAuthorization : TxRlp.encodeNone();
+
+        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        return abi.encodePacked(bytes1(0x76), rlpPayload);
+    }
+
+    /// @notice RLP encodes the signed transaction with type prefix 0x76.
+    function encodeWithSignature(TempoTransaction memory self, VmRlp vm, uint8 v, bytes32 r, bytes32 s)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes[] memory fields = new bytes[](17);
+
+        fields[0] = TxRlp.encodeUint(self.chainId);
+        fields[1] = TxRlp.encodeUint(self.maxPriorityFeePerGas);
+        fields[2] = TxRlp.encodeUint(self.maxFeePerGas);
+        fields[3] = TxRlp.encodeUint(self.gasLimit);
+        fields[4] = encodeCalls(vm, self.calls);
+        fields[5] = encodeAccessList(vm, self.accessList);
+        fields[6] = TxRlp.encodeUint(self.nonceKey);
+        fields[7] = TxRlp.encodeUint(self.nonce);
+        fields[8] = self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone();
+        fields[9] = self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone();
+        fields[10] = self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone();
+        fields[11] = self.hasFeePayerSignature ? self.feePayerSignature : TxRlp.encodeNone();
+        fields[12] = encodeAuthorizationList(vm, self.authorizationList);
+        fields[13] = self.hasKeyAuthorization ? self.keyAuthorization : TxRlp.encodeNone();
+        fields[14] = TxRlp.encodeUint(v);
+        fields[15] = TxRlp.encodeBytes32(r);
+        fields[16] = TxRlp.encodeBytes32(s);
+
+        bytes memory rlpPayload = TxRlp.encodeList(vm, fields);
+        return abi.encodePacked(bytes1(0x76), rlpPayload);
+    }
+
+    /// @notice Encodes the calls array as an RLP list.
+    function encodeCalls(VmRlp vm, TempoCall[] memory calls) internal pure returns (bytes memory) {
+        bytes[] memory encodedCalls = new bytes[](calls.length);
+        for (uint256 i = 0; i < calls.length; i++) {
+            bytes[] memory callFields = new bytes[](3);
+            callFields[0] = TxRlp.encodeAddress(calls[i].to);
+            callFields[1] = TxRlp.encodeUint(calls[i].value);
+            callFields[2] = calls[i].data;
+            encodedCalls[i] = TxRlp.encodeList(vm, callFields);
+        }
+        return TxRlp.encodeList(vm, encodedCalls);
+    }
+
+    /// @notice Encodes the access list as an RLP list.
+    function encodeAccessList(VmRlp vm, AccessListItem[] memory list) internal pure returns (bytes memory) {
+        bytes[] memory encodedItems = new bytes[](list.length);
+        for (uint256 i = 0; i < list.length; i++) {
+            bytes[] memory keys = new bytes[](list[i].storageKeys.length);
+            for (uint256 j = 0; j < list[i].storageKeys.length; j++) {
+                keys[j] = TxRlp.encodeBytes32Full(list[i].storageKeys[j]);
+            }
+            bytes[] memory itemFields = new bytes[](2);
+            itemFields[0] = TxRlp.encodeAddress(list[i].target);
+            itemFields[1] = TxRlp.encodeList(vm, keys);
+            encodedItems[i] = TxRlp.encodeList(vm, itemFields);
+        }
+        return TxRlp.encodeList(vm, encodedItems);
+    }
+
+    /// @notice Encodes the authorization list as an RLP list.
+    function encodeAuthorizationList(VmRlp vm, TempoAuthorization[] memory list) internal pure returns (bytes memory) {
+        bytes[] memory encodedAuths = new bytes[](list.length);
+        for (uint256 i = 0; i < list.length; i++) {
+            bytes[] memory authFields = new bytes[](6);
+            authFields[0] = TxRlp.encodeUint(list[i].chainId);
+            authFields[1] = TxRlp.encodeAddress(list[i].authority);
+            authFields[2] = TxRlp.encodeUint(list[i].nonce);
+            authFields[3] = TxRlp.encodeUint(list[i].yParity);
+            authFields[4] = TxRlp.encodeBytes32(list[i].r);
+            authFields[5] = TxRlp.encodeBytes32(list[i].s);
+            encodedAuths[i] = TxRlp.encodeList(vm, authFields);
+        }
+        return TxRlp.encodeList(vm, encodedAuths);
+    }
+}

--- a/src/tx/TempoTransactionLib.sol
+++ b/src/tx/TempoTransactionLib.sol
@@ -46,7 +46,12 @@ struct TempoTransaction {
 }
 
 /// @title Builder and RLP encoder for Tempo transactions (type 0x76).
+/// @dev Encoding follows the Tempo spec where signed transactions have 15 fields:
+///      14 transaction fields + 1 signature field (65-byte secp256k1: r || s || v)
 library TempoTransactionLib {
+    /// @notice Tempo transaction type prefix.
+    uint8 internal constant TX_TYPE = 0x76;
+
     /// @notice Creates a new Tempo transaction with default values.
     function create() internal pure returns (TempoTransaction memory tx_) {
         tx_.gasLimit = 21000;
@@ -198,84 +203,109 @@ library TempoTransactionLib {
     }
 
     /// @notice RLP encodes the unsigned transaction with type prefix 0x76.
-    function encode(TempoTransaction memory self, VmRlp vm) internal pure returns (bytes memory) {
-        bytes[] memory fields = new bytes[](14);
+    /// @dev Format: 0x76 || RLP([chainId, maxPriorityFeePerGas, maxFeePerGas, gasLimit, calls, accessList,
+    ///              nonceKey, nonce, validBefore, validAfter, feeToken, feePayerSignature, authorizationList, keyAuthorization])
+    ///      Note: keyAuthorization is truly optional (no bytes if not present)
+    function encode(TempoTransaction memory self, VmRlp) internal pure returns (bytes memory) {
+        // 13 mandatory fields + 1 optional keyAuthorization
+        uint256 fieldCount = self.hasKeyAuthorization ? 14 : 13;
+        bytes[] memory fields = new bytes[](fieldCount);
 
+        // Scalar fields: encode value then wrap with RLP string prefix
         fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
         fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
         fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
         fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
-        fields[4] = encodeCalls(vm, self.calls);
-        fields[5] = encodeAccessList(vm, self.accessList);
+
+        // Nested lists: already fully RLP encoded, pass directly
+        fields[4] = _encodeCalls(self.calls);
+        fields[5] = _encodeAccessList(self.accessList);
+
+        // More scalar fields
         fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
         fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
-        fields[8] = self.hasValidBefore
-            ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore))
-            : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[9] = self.hasValidAfter
-            ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter))
-            : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[10] = self.hasFeeToken
-            ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken))
-            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[8] = TxRlp.encodeString(self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone());
+        fields[9] = TxRlp.encodeString(self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone());
+        fields[10] = TxRlp.encodeString(self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone());
+
+        // Fee payer signature: encoded as RLP list [v, r, s] if present, else 0x80
         fields[11] = self.hasFeePayerSignature
-            ? TxRlp.encodeString(self.feePayerSignature)
-            : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[12] = encodeAuthorizationList(vm, self.authorizationList);
-        fields[13] = self.hasKeyAuthorization
-            ? TxRlp.encodeString(self.keyAuthorization)
+            ? _encodeFeePayerSignature(self.feePayerSignature)
             : TxRlp.encodeString(TxRlp.encodeNone());
 
+        // Authorization list (always present, can be empty)
+        fields[12] = _encodeAuthorizationList(self.authorizationList);
+
+        // Key authorization is truly optional (no bytes if not present)
+        if (self.hasKeyAuthorization) {
+            fields[13] = TxRlp.encodeString(self.keyAuthorization);
+        }
+
         bytes memory rlpPayload = TxRlp.encodeRawList(fields);
-        return abi.encodePacked(bytes1(0x76), rlpPayload);
+        return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
     /// @notice RLP encodes the signed transaction with type prefix 0x76.
-    function encodeWithSignature(TempoTransaction memory self, VmRlp vm, uint8 v, bytes32 r, bytes32 s)
+    /// @dev Format: 0x76 || RLP([...14 fields, signature_bytes])
+    ///      The signature is a 65-byte secp256k1 signature: r (32) || s (32) || v (1)
+    /// @param v The recovery parameter (27 or 28 from vm.sign). Will be stored as-is in the signature bytes.
+    function encodeWithSignature(TempoTransaction memory self, VmRlp, uint8 v, bytes32 r, bytes32 s)
         internal
         pure
         returns (bytes memory)
     {
-        bytes[] memory fields = new bytes[](17);
+        // 13 or 14 tx fields + 1 signature field
+        uint256 fieldCount = self.hasKeyAuthorization ? 15 : 14;
+        bytes[] memory fields = new bytes[](fieldCount);
 
+        // Encode all transaction fields (same as unsigned)
         fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
         fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
         fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
         fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
-        fields[4] = encodeCalls(vm, self.calls);
-        fields[5] = encodeAccessList(vm, self.accessList);
+        fields[4] = _encodeCalls(self.calls);
+        fields[5] = _encodeAccessList(self.accessList);
         fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
         fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
-        fields[8] = self.hasValidBefore
-            ? TxRlp.encodeString(TxRlp.encodeUint(self.validBefore))
-            : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[9] = self.hasValidAfter
-            ? TxRlp.encodeString(TxRlp.encodeUint(self.validAfter))
-            : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[10] = self.hasFeeToken
-            ? TxRlp.encodeString(TxRlp.encodeAddress(self.feeToken))
-            : TxRlp.encodeString(TxRlp.encodeNone());
+        fields[8] = TxRlp.encodeString(self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone());
+        fields[9] = TxRlp.encodeString(self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone());
+        fields[10] = TxRlp.encodeString(self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone());
         fields[11] = self.hasFeePayerSignature
-            ? TxRlp.encodeString(self.feePayerSignature)
+            ? _encodeFeePayerSignature(self.feePayerSignature)
             : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[12] = encodeAuthorizationList(vm, self.authorizationList);
-        fields[13] = self.hasKeyAuthorization
-            ? TxRlp.encodeString(self.keyAuthorization)
-            : TxRlp.encodeString(TxRlp.encodeNone());
-        fields[14] = TxRlp.encodeString(TxRlp.encodeUint(v));
-        fields[15] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
-        fields[16] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
+        fields[12] = _encodeAuthorizationList(self.authorizationList);
+
+        uint256 sigFieldIdx;
+        if (self.hasKeyAuthorization) {
+            fields[13] = TxRlp.encodeString(self.keyAuthorization);
+            sigFieldIdx = 14;
+        } else {
+            sigFieldIdx = 13;
+        }
+
+        // Signature field: 65 bytes (r || s || v) encoded as RLP bytes string
+        // Note: For secp256k1, the format is r (32 bytes) || s (32 bytes) || v (1 byte)
+        bytes memory sigBytes = abi.encodePacked(r, s, v);
+        fields[sigFieldIdx] = TxRlp.encodeString(sigBytes);
 
         bytes memory rlpPayload = TxRlp.encodeRawList(fields);
-        return abi.encodePacked(bytes1(0x76), rlpPayload);
+        return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
     /// @notice Encodes the calls array as an RLP list.
-    function encodeCalls(VmRlp, TempoCall[] memory calls) internal pure returns (bytes memory) {
+    /// @dev Each call is encoded as [to, value, data].
+    ///      For CREATE calls (to == address(0)), `to` is encoded as empty string (0x80)
+    ///      to match Rust's TxKind::Create encoding.
+    function _encodeCalls(TempoCall[] memory calls) private pure returns (bytes memory) {
         bytes[] memory encodedCalls = new bytes[](calls.length);
         for (uint256 i = 0; i < calls.length; i++) {
             bytes[] memory callFields = new bytes[](3);
-            callFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(calls[i].to));
+            // CREATE is encoded as empty string, CALL is encoded as 20-byte address
+            if (calls[i].to == address(0)) {
+                callFields[0] = TxRlp.encodeString(TxRlp.encodeNone()); // CREATE: empty string
+            } else {
+                callFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(calls[i].to));
+            }
             callFields[1] = TxRlp.encodeString(TxRlp.encodeUint(calls[i].value));
             callFields[2] = TxRlp.encodeString(calls[i].data);
             encodedCalls[i] = TxRlp.encodeRawList(callFields);
@@ -284,23 +314,26 @@ library TempoTransactionLib {
     }
 
     /// @notice Encodes the access list as an RLP list.
-    function encodeAccessList(VmRlp, AccessListItem[] memory list) internal pure returns (bytes memory) {
+    /// @dev Each item is encoded as [address, [storageKey1, storageKey2, ...]].
+    function _encodeAccessList(AccessListItem[] memory list) private pure returns (bytes memory) {
         bytes[] memory encodedItems = new bytes[](list.length);
         for (uint256 i = 0; i < list.length; i++) {
             bytes[] memory keys = new bytes[](list[i].storageKeys.length);
             for (uint256 j = 0; j < list[i].storageKeys.length; j++) {
                 keys[j] = TxRlp.encodeString(TxRlp.encodeBytes32Full(list[i].storageKeys[j]));
             }
+            bytes memory keysList = TxRlp.encodeRawList(keys);
+
             bytes[] memory itemFields = new bytes[](2);
             itemFields[0] = TxRlp.encodeString(TxRlp.encodeAddress(list[i].target));
-            itemFields[1] = TxRlp.encodeRawList(keys);
+            itemFields[1] = keysList; // Already a fully encoded list
             encodedItems[i] = TxRlp.encodeRawList(itemFields);
         }
         return TxRlp.encodeRawList(encodedItems);
     }
 
     /// @notice Encodes the authorization list as an RLP list.
-    function encodeAuthorizationList(VmRlp, TempoAuthorization[] memory list) internal pure returns (bytes memory) {
+    function _encodeAuthorizationList(TempoAuthorization[] memory list) private pure returns (bytes memory) {
         bytes[] memory encodedAuths = new bytes[](list.length);
         for (uint256 i = 0; i < list.length; i++) {
             bytes[] memory authFields = new bytes[](6);
@@ -313,5 +346,44 @@ library TempoTransactionLib {
             encodedAuths[i] = TxRlp.encodeRawList(authFields);
         }
         return TxRlp.encodeRawList(encodedAuths);
+    }
+
+    /// @notice Encodes fee payer signature as RLP list [v, r, s]
+    function _encodeFeePayerSignature(bytes memory sig) private pure returns (bytes memory) {
+        require(sig.length == 65, "Invalid fee payer signature length");
+
+        // Parse signature: first 32 bytes = r, next 32 = s, last byte = v
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(sig, 32))
+            s := mload(add(sig, 64))
+            v := byte(0, mload(add(sig, 96)))
+        }
+
+        // Encode as RLP list [r, s, v] matching Rust's write_rlp_vrs order
+        bytes[] memory sigFields = new bytes[](3);
+        sigFields[0] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
+        sigFields[1] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
+        sigFields[2] = TxRlp.encodeString(TxRlp.encodeUint(v));
+        return TxRlp.encodeRawList(sigFields);
+    }
+
+    // ============ Legacy function signatures for backwards compatibility ============
+
+    /// @notice Encodes the calls array as an RLP list (legacy signature).
+    function encodeCalls(VmRlp, TempoCall[] memory calls) internal pure returns (bytes memory) {
+        return _encodeCalls(calls);
+    }
+
+    /// @notice Encodes the access list as an RLP list (legacy signature).
+    function encodeAccessList(VmRlp, AccessListItem[] memory list) internal pure returns (bytes memory) {
+        return _encodeAccessList(list);
+    }
+
+    /// @notice Encodes the authorization list as an RLP list (legacy signature).
+    function encodeAuthorizationList(VmRlp, TempoAuthorization[] memory list) internal pure returns (bytes memory) {
+        return _encodeAuthorizationList(list);
     }
 }

--- a/src/tx/TxRlp.sol
+++ b/src/tx/TxRlp.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {VmRlp} from "../StdVm.sol";
 
 /// @title RLP encoding helpers for transaction builders.
+/// @dev Local copy for test use - does not depend on tempo-std VmRlp
 library TxRlp {
     /// @notice Encodes a uint256 as minimal big-endian bytes (no leading zeros).
     /// @dev Zero is encoded as empty bytes per RLP spec.
@@ -12,7 +13,6 @@ library TxRlp {
             return "";
         }
 
-        // Count bytes needed
         uint256 temp = value;
         uint256 len = 0;
         while (temp > 0) {
@@ -20,11 +20,11 @@ library TxRlp {
             temp >>= 8;
         }
 
-        // Build result in big-endian order
         bytes memory result = new bytes(len);
         for (uint256 i = len; i > 0; i--) {
+            // Intentional truncation: extracting lowest byte
             // forge-lint: disable-next-line(unsafe-typecast)
-            result[i - 1] = bytes1(uint8(value)); // Safe: extracting lowest byte
+            result[i - 1] = bytes1(uint8(value));
             value >>= 8;
         }
         return result;
@@ -41,13 +41,11 @@ library TxRlp {
     }
 
     /// @notice Encodes a bytes32 as minimal bytes (leading zeros stripped).
-    /// @dev Used for signature r and s values in RLP encoding.
     function encodeBytes32(bytes32 b) internal pure returns (bytes memory) {
         return encodeUint(uint256(b));
     }
 
     /// @notice Encodes a bytes32 as full 32 bytes (no stripping).
-    /// @dev Used for storage keys in access lists.
     function encodeBytes32Full(bytes32 b) internal pure returns (bytes memory) {
         return abi.encodePacked(b);
     }
@@ -58,29 +56,20 @@ library TxRlp {
     }
 
     /// @notice RLP encodes a raw string (bytes) with proper RLP prefix.
-    /// @dev For a string of length n:
-    ///      - If n == 1 and byte < 0x80: no prefix (single byte is itself)
-    ///      - If n <= 55: prefix is (0x80 + n)
-    ///      - If n > 55: prefix is (0xb7 + length of n in bytes) followed by n in big-endian
     function encodeString(bytes memory str) internal pure returns (bytes memory) {
         uint256 len = str.length;
 
         if (len == 1 && uint8(str[0]) < 0x80) {
             return str;
         } else if (len <= 55) {
-            // forge-lint: disable-next-line(unsafe-typecast)
-            return abi.encodePacked(bytes1(uint8(0x80 + len)), str); // Safe: len <= 55, so 0x80 + len <= 0xb7
+            return abi.encodePacked(bytes1(uint8((0x80 + len) & 0xff)), str);
         } else {
             bytes memory lenBytes = encodeLength(len);
-            return abi.encodePacked(bytes1(uint8(0xb7 + lenBytes.length)), lenBytes, str);
+            return abi.encodePacked(bytes1(uint8((0xb7 + lenBytes.length) & 0xff)), lenBytes, str);
         }
     }
 
     /// @notice Concatenates already RLP-encoded items and wraps them as an RLP list.
-    /// @dev This is used for nested lists where inner items are already RLP-encoded.
-    ///      The function concatenates all items, then adds the appropriate list prefix.
-    /// @param encodedItems Array of already RLP-encoded items.
-    /// @return The RLP-encoded list containing all items.
     function encodeRawList(bytes[] memory encodedItems) internal pure returns (bytes memory) {
         uint256 totalLen = 0;
         for (uint256 i = 0; i < encodedItems.length; i++) {
@@ -100,17 +89,13 @@ library TxRlp {
     }
 
     /// @notice Prepends the RLP list prefix to a payload.
-    /// @dev For a list with payload length n:
-    ///      - If n <= 55: prefix is (0xc0 + n)
-    ///      - If n > 55: prefix is (0xf7 + length of n in bytes) followed by n in big-endian
     function prependListPrefix(bytes memory payload) internal pure returns (bytes memory) {
         uint256 len = payload.length;
         if (len <= 55) {
-            // forge-lint: disable-next-line(unsafe-typecast)
-            return abi.encodePacked(bytes1(uint8(0xc0 + len)), payload); // Safe: len <= 55, so 0xc0 + len <= 0xf7
+            return abi.encodePacked(bytes1(uint8((0xc0 + len) & 0xff)), payload);
         } else {
             bytes memory lenBytes = encodeLength(len);
-            return abi.encodePacked(bytes1(uint8(0xf7 + lenBytes.length)), lenBytes, payload);
+            return abi.encodePacked(bytes1(uint8((0xf7 + lenBytes.length) & 0xff)), lenBytes, payload);
         }
     }
 
@@ -129,8 +114,9 @@ library TxRlp {
 
         bytes memory result = new bytes(numBytes);
         for (uint256 i = numBytes; i > 0; i--) {
+            // Intentional truncation: extracting lowest byte
             // forge-lint: disable-next-line(unsafe-typecast)
-            result[i - 1] = bytes1(uint8(len)); // Safe: extracting lowest byte
+            result[i - 1] = bytes1(uint8(len));
             len >>= 8;
         }
         return result;

--- a/src/tx/TxRlp.sol
+++ b/src/tx/TxRlp.sol
@@ -56,4 +56,83 @@ library TxRlp {
     function encodeList(VmRlp vm, bytes[] memory items) internal pure returns (bytes memory) {
         return vm.toRlp(items);
     }
+
+    /// @notice RLP encodes a raw string (bytes) with proper RLP prefix.
+    /// @dev For a string of length n:
+    ///      - If n == 1 and byte < 0x80: no prefix (single byte is itself)
+    ///      - If n <= 55: prefix is (0x80 + n)
+    ///      - If n > 55: prefix is (0xb7 + length of n in bytes) followed by n in big-endian
+    function encodeString(bytes memory str) internal pure returns (bytes memory) {
+        uint256 len = str.length;
+
+        if (len == 1 && uint8(str[0]) < 0x80) {
+            return str;
+        } else if (len <= 55) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            return abi.encodePacked(bytes1(uint8(0x80 + len)), str); // Safe: len <= 55, so 0x80 + len <= 0xb7
+        } else {
+            bytes memory lenBytes = encodeLength(len);
+            return abi.encodePacked(bytes1(uint8(0xb7 + lenBytes.length)), lenBytes, str);
+        }
+    }
+
+    /// @notice Concatenates already RLP-encoded items and wraps them as an RLP list.
+    /// @dev This is used for nested lists where inner items are already RLP-encoded.
+    ///      The function concatenates all items, then adds the appropriate list prefix.
+    /// @param encodedItems Array of already RLP-encoded items.
+    /// @return The RLP-encoded list containing all items.
+    function encodeRawList(bytes[] memory encodedItems) internal pure returns (bytes memory) {
+        uint256 totalLen = 0;
+        for (uint256 i = 0; i < encodedItems.length; i++) {
+            totalLen += encodedItems[i].length;
+        }
+
+        bytes memory payload = new bytes(totalLen);
+        uint256 offset = 0;
+        for (uint256 i = 0; i < encodedItems.length; i++) {
+            bytes memory item = encodedItems[i];
+            for (uint256 j = 0; j < item.length; j++) {
+                payload[offset++] = item[j];
+            }
+        }
+
+        return prependListPrefix(payload);
+    }
+
+    /// @notice Prepends the RLP list prefix to a payload.
+    /// @dev For a list with payload length n:
+    ///      - If n <= 55: prefix is (0xc0 + n)
+    ///      - If n > 55: prefix is (0xf7 + length of n in bytes) followed by n in big-endian
+    function prependListPrefix(bytes memory payload) internal pure returns (bytes memory) {
+        uint256 len = payload.length;
+        if (len <= 55) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            return abi.encodePacked(bytes1(uint8(0xc0 + len)), payload); // Safe: len <= 55, so 0xc0 + len <= 0xf7
+        } else {
+            bytes memory lenBytes = encodeLength(len);
+            return abi.encodePacked(bytes1(uint8(0xf7 + lenBytes.length)), lenBytes, payload);
+        }
+    }
+
+    /// @notice Encodes a length as minimal big-endian bytes.
+    function encodeLength(uint256 len) internal pure returns (bytes memory) {
+        if (len == 0) {
+            return "";
+        }
+
+        uint256 temp = len;
+        uint256 numBytes = 0;
+        while (temp > 0) {
+            numBytes++;
+            temp >>= 8;
+        }
+
+        bytes memory result = new bytes(numBytes);
+        for (uint256 i = numBytes; i > 0; i--) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            result[i - 1] = bytes1(uint8(len)); // Safe: extracting lowest byte
+            len >>= 8;
+        }
+        return result;
+    }
 }

--- a/src/tx/TxRlp.sol
+++ b/src/tx/TxRlp.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {VmRlp} from "../StdVm.sol";
+
+/// @title RLP encoding helpers for transaction builders.
+library TxRlp {
+    /// @notice Encodes a uint256 as minimal big-endian bytes (no leading zeros).
+    /// @dev Zero is encoded as empty bytes per RLP spec.
+    function encodeUint(uint256 value) internal pure returns (bytes memory) {
+        if (value == 0) {
+            return "";
+        }
+
+        // Count bytes needed
+        uint256 temp = value;
+        uint256 len = 0;
+        while (temp > 0) {
+            len++;
+            temp >>= 8;
+        }
+
+        // Build result in big-endian order
+        bytes memory result = new bytes(len);
+        for (uint256 i = len; i > 0; i--) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            result[i - 1] = bytes1(uint8(value)); // Safe: extracting lowest byte
+            value >>= 8;
+        }
+        return result;
+    }
+
+    /// @notice Encodes an address as 20 bytes.
+    function encodeAddress(address a) internal pure returns (bytes memory) {
+        return abi.encodePacked(a);
+    }
+
+    /// @notice Returns empty bytes for RLP "None" / empty string.
+    function encodeNone() internal pure returns (bytes memory) {
+        return "";
+    }
+
+    /// @notice Encodes a bytes32 as minimal bytes (leading zeros stripped).
+    /// @dev Used for signature r and s values in RLP encoding.
+    function encodeBytes32(bytes32 b) internal pure returns (bytes memory) {
+        return encodeUint(uint256(b));
+    }
+
+    /// @notice Encodes a bytes32 as full 32 bytes (no stripping).
+    /// @dev Used for storage keys in access lists.
+    function encodeBytes32Full(bytes32 b) internal pure returns (bytes memory) {
+        return abi.encodePacked(b);
+    }
+
+    /// @notice RLP encodes a list using the Vm cheatcode.
+    function encodeList(VmRlp vm, bytes[] memory items) internal pure returns (bytes memory) {
+        return vm.toRlp(items);
+    }
+}


### PR DESCRIPTION
Add Solidity libraries for building and RLP-encoding transactions:

- `LegacyTransactionLib` - Legacy transactions (no type prefix)
- `Eip1559TransactionLib` - EIP-1559 transactions (type 0x02)
- `Eip7702TransactionLib` - EIP-7702 transactions (type 0x04)
- `TempoTransactionLib` - Tempo transactions (type 0x76)

Also adds `VmRlp` and `VmExecuteTransaction` interfaces for the `vm.toRlp()` and `vm.executeTransaction()` cheatcodes.

## Usage

```solidity
using LegacyTransactionLib for LegacyTransaction;

VmRlp rlp = VmRlp(address(vm));
VmExecuteTransaction txVm = VmExecuteTransaction(address(vm));

bytes memory rawTx = LegacyTransactionLib.create()
    .withNonce(0)
    .withGasPrice(100)
    .withGasLimit(100000)
    .withTo(target)
    .withData(calldata)
    .encodeWithSignature(rlp, v, r, s);

bytes memory result = txVm.executeTransaction(rawTx);
```