### PR TITLE
fix(sync): update path to new tips/ref-impls structure

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -23,7 +23,7 @@ function main () {
 
     # Clone specs repo and copy interface specs
     git clone --depth 1 https://github.com/tempoxyz/tempo.git specs
-    cp -r specs/docs/specs/src/interfaces src
+    cp -r specs/tips/ref-impls/src/interfaces src
     rm -rf specs
 
     # Remove redundant files


### PR DESCRIPTION
Updates the sync script to use the new `tips/ref-impls/src/interfaces` path instead of the old `docs/specs/src/interfaces` path.

Related: https://github.com/tempoxyz/tempo/pull/2202