### PR TITLE
fix: encode fee payer signature as [v, r, s] with normalized parity

### DIFF
--- a/src/tx/TempoTransactionLib.sol
+++ b/src/tx/TempoTransactionLib.sol
@@ -362,11 +362,14 @@ library TempoTransactionLib {
             v := byte(0, mload(add(sig, 96)))
         }
 
-        // Encode as RLP list [r, s, v] matching Rust's write_rlp_vrs order
+        // Normalize v from 27/28 to 0/1 parity (Rust decodes as bool)
+        uint8 parity = v >= 27 ? v - 27 : v;
+
+        // Encode as RLP list [v, r, s] matching Rust's Signature::write_rlp_vrs order
         bytes[] memory sigFields = new bytes[](3);
-        sigFields[0] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
-        sigFields[1] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
-        sigFields[2] = TxRlp.encodeString(TxRlp.encodeUint(v));
+        sigFields[0] = TxRlp.encodeString(TxRlp.encodeUint(parity));
+        sigFields[1] = TxRlp.encodeString(TxRlp.encodeBytes32(r));
+        sigFields[2] = TxRlp.encodeString(TxRlp.encodeBytes32(s));
         return TxRlp.encodeRawList(sigFields);
     }
 

--- a/src/tx/TempoTransactionLib.sol
+++ b/src/tx/TempoTransactionLib.sol
@@ -292,6 +292,87 @@ library TempoTransactionLib {
         return abi.encodePacked(TX_TYPE, rlpPayload);
     }
 
+    /// @notice Computes the user signing hash for the transaction.
+    /// @dev When a fee payer signature is present:
+    ///      - fee_token is SKIPPED (user doesn't commit to fee token)
+    ///      - fee payer signature field is encoded as a 0x00 placeholder byte
+    ///      This matches Rust's TempoTransaction::encode_for_signing / signature_hash.
+    function signingHash(TempoTransaction memory self, VmRlp) internal pure returns (bytes32) {
+        uint256 fieldCount = self.hasKeyAuthorization ? 14 : 13;
+        bytes[] memory fields = new bytes[](fieldCount);
+
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
+        fields[4] = _encodeCalls(self.calls);
+        fields[5] = _encodeAccessList(self.accessList);
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
+        fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[8] = TxRlp.encodeString(self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone());
+        fields[9] = TxRlp.encodeString(self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone());
+
+        // When fee payer sig is present, skip fee_token (encode as empty)
+        if (self.hasFeePayerSignature) {
+            fields[10] = TxRlp.encodeString(TxRlp.encodeNone());
+        } else {
+            fields[10] = TxRlp.encodeString(self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone());
+        }
+
+        // Fee payer signature: 0x00 placeholder if present, else 0x80
+        if (self.hasFeePayerSignature) {
+            fields[11] = TxRlp.encodeString(abi.encodePacked(uint8(0)));
+        } else {
+            fields[11] = TxRlp.encodeString(TxRlp.encodeNone());
+        }
+
+        fields[12] = _encodeAuthorizationList(self.authorizationList);
+
+        if (self.hasKeyAuthorization) {
+            fields[13] = TxRlp.encodeString(self.keyAuthorization);
+        }
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
+        return keccak256(abi.encodePacked(TX_TYPE, rlpPayload));
+    }
+
+    /// @notice Computes the fee payer signature hash.
+    /// @dev The fee payer signs this hash to sponsor the transaction. Format:
+    ///      keccak256(0x78 || RLP([...all fields with sender address in place of feePayerSignature...]))
+    ///      This matches Rust's TempoTransaction::fee_payer_signature_hash().
+    function feePayerSignatureHash(TempoTransaction memory self, VmRlp, address sender)
+        internal
+        pure
+        returns (bytes32)
+    {
+        uint256 fieldCount = self.hasKeyAuthorization ? 14 : 13;
+        bytes[] memory fields = new bytes[](fieldCount);
+
+        fields[0] = TxRlp.encodeString(TxRlp.encodeUint(self.chainId));
+        fields[1] = TxRlp.encodeString(TxRlp.encodeUint(self.maxPriorityFeePerGas));
+        fields[2] = TxRlp.encodeString(TxRlp.encodeUint(self.maxFeePerGas));
+        fields[3] = TxRlp.encodeString(TxRlp.encodeUint(self.gasLimit));
+        fields[4] = _encodeCalls(self.calls);
+        fields[5] = _encodeAccessList(self.accessList);
+        fields[6] = TxRlp.encodeString(TxRlp.encodeUint(self.nonceKey));
+        fields[7] = TxRlp.encodeString(TxRlp.encodeUint(self.nonce));
+        fields[8] = TxRlp.encodeString(self.hasValidBefore ? TxRlp.encodeUint(self.validBefore) : TxRlp.encodeNone());
+        fields[9] = TxRlp.encodeString(self.hasValidAfter ? TxRlp.encodeUint(self.validAfter) : TxRlp.encodeNone());
+        fields[10] = TxRlp.encodeString(self.hasFeeToken ? TxRlp.encodeAddress(self.feeToken) : TxRlp.encodeNone());
+
+        // Sender address in place of fee payer signature (matching Rust)
+        fields[11] = TxRlp.encodeString(TxRlp.encodeAddress(sender));
+
+        fields[12] = _encodeAuthorizationList(self.authorizationList);
+
+        if (self.hasKeyAuthorization) {
+            fields[13] = TxRlp.encodeString(self.keyAuthorization);
+        }
+
+        bytes memory rlpPayload = TxRlp.encodeRawList(fields);
+        return keccak256(abi.encodePacked(uint8(0x78), rlpPayload));
+    }
+
     /// @notice Encodes the calls array as an RLP list.
     /// @dev Each call is encoded as [to, value, data].
     ///      For CREATE calls (to == address(0)), `to` is encoded as empty string (0x80)


### PR DESCRIPTION
## Summary
Fix fee payer signature RLP encoding order and parity normalization.

## Motivation
`_encodeFeePayerSignature` encoded as `[r, s, v]` but Rust's `Signature::decode_rlp_vrs` expects `[v, r, s]`. Also `v` was 27/28 but Rust decodes as bool (0/1), causing RLP overflow.

## Changes
- Reorder from `[r, s, v]` to `[v, r, s]` in `TempoTransactionLib.sol`
- Normalize v from 27/28 to 0/1 parity
