### PR TITLE
fix: correct 8 broken documentation URLs and tree formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ forge install tempoxyz/tempo-std
 <pre>
 src
 ├── interfaces
-│   ├── <a href="./src/interfaces/IAccountKeychain.sol">IAccountKeychain.sol</a>: Account Keychain | <a href="https://docs.tempo.xyz/documentation/protocol/transactions/spec-tempo-transaction#keychain-precompile">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/account_keychain/mod.rs">Implementation</a>
-│   ├── <a href="./src/interfaces/IFeeAMM.sol">IFeeAMM.sol</a>: Fee AMM | <a href="https://docs.tempo.xyz/documentation/protocol/fees/fee-amm">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip_fee_manager/amm.rs">Implementation</a>
-│   ├── <a href="./src/interfaces/IFeeManager.sol">IFeeManager.sol</a>: Fee AMM Management | <a href="https://docs.tempo.xyz/documentation/protocol/fees/spec-fee-amm#2-feemanager-contract">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip_fee_manager/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/IAccountKeychain.sol">IAccountKeychain.sol</a>: Account Keychain | <a href="https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#keychain-precompile">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/account_keychain/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/IFeeAMM.sol">IFeeAMM.sol</a>: Fee AMM | <a href="https://docs.tempo.xyz/protocol/fees/fee-amm">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip_fee_manager/amm.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/IFeeManager.sol">IFeeManager.sol</a>: Fee AMM Management | <a href="https://docs.tempo.xyz/protocol/fees/spec-fee-amm#2-feemanager-contract">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip_fee_manager/mod.rs">Implementation</a>
 │   ├── <a href="./src/interfaces/INonce.sol">INonce.sol</a>: 2D Nonce Management for Tempo Transactions | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/nonce/mod.rs">Implementation</a>
 │   ├── <a href="./src/interfaces/IStablecoinDEX.sol">IStablecoinDEX.sol</a>: Stablecoin DEX | <a href="https://docs.tempo.xyz/protocol/exchange/spec#stablecoin-dex">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/stablecoin_dex/mod.rs">Implementation</a>
-│   ├── <a href="./src/interfaces/ITIP20Factory.sol">ITIP20Factory.sol</a>: TIP-20: Factory Contract | <a href="https://docs.tempo.xyz/documentation/protocol/tip20/spec#tip20factory">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20_factory/mod.rs">Implementation</a>
-│   ├── <a href="./src/interfaces/ITIP20RewardsRegistry.sol">ITIP20RewardsRegistry.sol</a>: TIP-20: Reward Distribution | <a href="https://docs.tempo.xyz/documentation/protocol/tip20-rewards/spec">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20_rewards_registry/mod.rs">Implementation</a>
-│   ├── <a href="./src/interfaces/ITIP20RolesAuth.sol">ITIP20RolesAuth.sol</a>: TIP-20: Roles & Permissions | <a href="https://docs.tempo.xyz/documentation/protocol/tip20/spec#role-based-access-control">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20/roles.rs">Implementation</a>
-│   ├── <a href="./src/interfaces/ITIP20.sol">ITIP20.sol</a>: TIP-20: Core Token Standard | <a href="https://docs.tempo.xyz/documentation/protocol/tip20/overview">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20/mod.rs">Implementation</a>
-│   └── <a href="./src/interfaces/ITIP403Registry.sol">ITIP403Registry.sol</a>: TIP-403: Policy Registry System | <a href="https://docs.tempo.xyz/documentation/protocol/tip403/overview">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip403_registry/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/ITIP20Factory.sol">ITIP20Factory.sol</a>: TIP-20: Factory Contract | <a href="https://docs.tempo.xyz/protocol/tip20/spec#tip20factory">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20_factory/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/ITIP20RewardsRegistry.sol">ITIP20RewardsRegistry.sol</a>: TIP-20: Reward Distribution | <a href="https://docs.tempo.xyz/protocol/tip20-rewards/spec">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20_rewards_registry/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/ITIP20RolesAuth.sol">ITIP20RolesAuth.sol</a>: TIP-20: Roles & Permissions | <a href="https://docs.tempo.xyz/protocol/tip20/spec#role-based-access-control">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20/roles.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/ITIP20.sol">ITIP20.sol</a>: TIP-20: Core Token Standard | <a href="https://docs.tempo.xyz/protocol/tip20/overview">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/ITIP403Registry.sol">ITIP403Registry.sol</a>: TIP-403: Policy Registry System | <a href="https://docs.tempo.xyz/protocol/tip403/overview">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip403_registry/mod.rs">Implementation</a>
 │   └── <a href="./src/interfaces/IValidatorConfig.sol">IValidatorConfig.sol</a>: Manage consensus validators | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/validator_config/mod.rs">Implementation</a>
 └── <a href="./src/StdPrecompiles.sol">StdPrecompiles.sol</a>: Collection of precompiles and their interfaces on Tempo
 </pre>
@@ -100,5 +100,5 @@ Licensed under either of [Apache License](./LICENSE-APACHE), Version
 2.0 or [MIT License](./LICENSE-MIT) at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in these crates by you, as defined in the Apache-2.0 license,
+for inclusion in these packages by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
## Summary

- **Fix 8 broken documentation URLs** — Links use `docs.tempo.xyz/documentation/protocol/...` but the correct path is `docs.tempo.xyz/protocol/...` (the `/documentation/` prefix causes 404s)
- **Fix tree structure** — `ITIP403Registry.sol` uses `└──` (last-item marker) but `IValidatorConfig.sol` follows at the same depth; changed to `├──`
- **Fix terminology** — "crates" → "packages" (this is a Solidity project, not Rust)

## Affected URLs

| Interface | Before (404) | After (correct) |
|-----------|------|-------|
| IAccountKeychain | `docs.tempo.xyz/documentation/protocol/transactions/...` | `docs.tempo.xyz/protocol/transactions/...` |
| IFeeAMM | `docs.tempo.xyz/documentation/protocol/fees/...` | `docs.tempo.xyz/protocol/fees/...` |
| IFeeManager | `docs.tempo.xyz/documentation/protocol/fees/...` | `docs.tempo.xyz/protocol/fees/...` |
| ITIP20Factory | `docs.tempo.xyz/documentation/protocol/tip20/...` | `docs.tempo.xyz/protocol/tip20/...` |
| ITIP20RewardsRegistry | `docs.tempo.xyz/documentation/protocol/tip20-rewards/...` | `docs.tempo.xyz/protocol/tip20-rewards/...` |
| ITIP20RolesAuth | `docs.tempo.xyz/documentation/protocol/tip20/...` | `docs.tempo.xyz/protocol/tip20/...` |
| ITIP20 | `docs.tempo.xyz/documentation/protocol/tip20/...` | `docs.tempo.xyz/protocol/tip20/...` |
| ITIP403Registry | `docs.tempo.xyz/documentation/protocol/tip403/...` | `docs.tempo.xyz/protocol/tip403/...` |

Note: `IStablecoinDEX` already had the correct URL (`docs.tempo.xyz/protocol/exchange/spec#stablecoin-dex`).

## Test plan

- [ ] Verify all 8 corrected documentation URLs resolve to the intended pages
- [ ] Verify tree structure renders correctly in GitHub markdown preview

