### PR TITLE
chore: update solc versions, add prerelease CI with dynamic matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,50 @@ on:
     branches:
       - master
 
+env:
+  SOLC_MINIMUM: "0.8.20"
+  SOLC_LATEST: "0.8.34"
+  SOLC_PRERELEASE: "0.8.35-pre.1"
+
 jobs:
+  build-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - id: generate
+        run: |
+          MINIMUM="${{ env.SOLC_MINIMUM }}"
+          LATEST="${{ env.SOLC_LATEST }}"
+          PRERELEASE="${{ env.SOLC_PRERELEASE }}"
+          matrix='{"include":['
+          for toolchain in stable nightly; do
+            for flags in \
+              "" \
+              "--via-ir" \
+              "--use solc:${LATEST}" \
+              "--use solc:${LATEST} --via-ir" \
+              "--use solc:${MINIMUM}" \
+              "--use solc:${MINIMUM} --via-ir"
+            do
+              matrix+='{"toolchain":"'"$toolchain"'","flags":"'"$flags"'","prerelease":false},'
+            done
+          done
+          # prerelease (nightly only, svm-rs is not up to date on stable)
+          for flags in \
+            "--use solc:${PRERELEASE}" \
+            "--use solc:${PRERELEASE} --via-ir"
+          do
+            matrix+='{"toolchain":"nightly","flags":"'"$flags"'","prerelease":true},'
+          done
+          matrix="${matrix%,}]}"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: build-matrix
     name: build +${{ matrix.toolchain }} ${{ matrix.flags }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -18,20 +60,17 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
-        flags:
-          - ""
-          - --via-ir
-          - --use solc:0.8.20 --via-ir
-          - --use solc:0.8.20
+      matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ matrix.toolchain }}
       - run: forge --version
-      - run: forge build --skip test --deny-warnings ${{ matrix.flags }}
+      # 3805: "This is a pre-release compiler version, please do not use it in production."
+      - run: forge build --skip test --deny warnings ${{ matrix.prerelease && '--ignored-error-codes 3805' || '' }} ${{ matrix.flags }}
 
   test:
     runs-on: ubuntu-latest
@@ -80,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - build-matrix
       - build
       - test
       - fmt


### PR DESCRIPTION
- Define `SOLC_MINIMUM`, `SOLC_LATEST`, and `SOLC_PRERELEASE` versions at the top of CI workflow for easy maintenance
- Generate build matrix dynamically so version changes only need a single update
- Run prerelease solc builds on `nightly` toolchain only (svm-rs is not up to date on `stable`)
- Ignore solc warning 3805 ("pre-release compiler version") for prerelease builds so `--deny warnings` does not fail on it
- Add `solc:0.8.34` (latest) build targets
- Fix missing `version` parameter on foundry-toolchain for build jobs
- Update deprecated `--deny-warnings` flag to `--deny warnings`