### PR TITLE
chore: supply chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,17 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
         with:
           version: ${{ matrix.toolchain }}
       - run: forge --version
       # 3805: "This is a pre-release compiler version, please do not use it in production."
-      - run: forge build --skip test --deny warnings ${{ matrix.prerelease && '--ignored-error-codes 3805' || '' }} ${{ matrix.flags }}
+      - run: forge build --skip test --deny warnings ${{ matrix.prerelease && '--ignored-error-codes 3805' || '' }} ${FORGE_FLAGS}
+        env:
+          FORGE_FLAGS: ${{ matrix.flags }}
 
   test:
     runs-on: ubuntu-latest
@@ -82,10 +84,10 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
         with:
           version: ${{ matrix.toolchain }}
       - run: forge --version
@@ -97,10 +99,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
       - run: forge --version
       - run: forge fmt --check
 
@@ -110,10 +112,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1
+      - uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0
 
   ci-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,7 +15,7 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'v0')
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
           fetch-depth: 0

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,13 +17,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
         with:
           version: nightly
 
@@ -35,7 +35,7 @@ jobs:
           scripts/sync.sh
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore: interface update"
           title: "chore: interface update"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -22,7 +22,7 @@ function main () {
     log $GREEN "Syncing specifications"
 
     # Clone specs repo and copy interface specs
-    git clone --depth 1 --branch v1.5.3 https://github.com/tempoxyz/tempo.git specs
+    git clone --depth 1 https://github.com/tempoxyz/tempo.git specs
     cp -r specs/tips/ref-impls/src/interfaces src
     rm -rf specs
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -22,7 +22,7 @@ function main () {
     log $GREEN "Syncing specifications"
 
     # Clone specs repo and copy interface specs
-    git clone --depth 1 https://github.com/tempoxyz/tempo.git specs
+    git clone --depth 1 --branch v1.5.3 https://github.com/tempoxyz/tempo.git specs
     cp -r specs/tips/ref-impls/src/interfaces src
     rm -rf specs
 


### PR DESCRIPTION
Supply chain hardening from dependency scan.

## Changes

- SHA-pin all GitHub Actions across ci.yml, sync.yml, update.yml
- Fix template injection: move `${{ matrix.flags }}` to env var in ci.yml
- Add Dependabot cooldown (7 days)
- Fix typos action version comment (`v1` → `v1.45.0`)

Prompted by: georgen