### PR TITLE
feat(IStablecoinDEX): add OrderFlipped event per TIP-1056

### DIFF
--- a/src/interfaces/IStablecoinDEX.sol
+++ b/src/interfaces/IStablecoinDEX.sol
@@ -63,6 +63,16 @@ interface IStablecoinDEX {
     event OrderFilled(
         uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill
     );
+    event OrderFlipped(
+        uint128 indexed orderId,
+        address indexed maker,
+        address indexed token,
+        uint128 amount,
+        bool isBid,
+        int16 tick,
+        bool isFlipOrder,
+        int16 flipTick
+    );
     event OrderPlaced(
         uint128 indexed orderId,
         address indexed maker,


### PR DESCRIPTION
Adds the `OrderFlipped` event to `IStablecoinDEX` per [TIP-1056](https://github.com/tempoxyz/tempo/pull/3755).

**Changes:**
- New `OrderFlipped` event with the same payload shape as `OrderPlaced`, emitted when a fully filled flip order is rewritten to its new resting state (instead of allocating a new `orderId` and emitting `OrderPlaced`).

No function signature changes — the TIP only adds a new event.