### PR TITLE
Remove redundant isFlipOrder from OrderFlipped event

### DIFF
--- a/src/interfaces/IStablecoinDEX.sol
+++ b/src/interfaces/IStablecoinDEX.sol
@@ -70,7 +70,6 @@ interface IStablecoinDEX {
         uint128 amount,
         bool isBid,
         int16 tick,
-        bool isFlipOrder,
         int16 flipTick
     );
     event OrderPlaced(


### PR DESCRIPTION
The `OrderFlipped` event is only emitted for flip orders, so `isFlipOrder` is always `true` and redundant.

Removing per review feedback on https://github.com/tempoxyz/tempo/pull/3776#discussion_r3208720792.