### PR TITLE
chore: add Stablecoin DEX FlipFailed event

### DIFF
--- a/src/interfaces/IStablecoinDEX.sol
+++ b/src/interfaces/IStablecoinDEX.sol
@@ -72,6 +72,7 @@ interface IStablecoinDEX {
         int16 tick,
         int16 flipTick
     );
+    event FlipFailed(uint128 indexed orderId, address indexed maker, bytes4 reason);
     event OrderPlaced(
         uint128 indexed orderId,
         address indexed maker,


### PR DESCRIPTION
## Summary

Adds the `FlipFailed(uint128 indexed orderId, address indexed maker, bytes4 reason)` event to `IStablecoinDEX` so `tempo-std` matches the Rust ABI changes in tempoxyz/tempo#4326.

## Root cause

The Tempo PR adds `FlipFailed` to the Rust `IStablecoinDEX` binding and emits it for swallowed flip failures, but `tempo-std` did not expose the same event. This caused the Tempo ABI alignment check to fail with:

`event missing in Solidity: FlipFailed(indexed uint128,indexed address,bytes4)`

## Validation

- `forge fmt --check`
- `forge build --skip test --deny warnings`
- `forge test -vvv` (no tests found)
- `cargo run -q -p tempo-xtask -- check-abi --tempo-std /Users/tanishkgoyal/Work/node/tempo-std --only IStablecoinDEX` from tempoxyz/tempo#4326 merge checkout
- `cargo run -q -p tempo-xtask -- check-abi --tempo-std /Users/tanishkgoyal/Work/node/tempo-std` from tempoxyz/tempo#4326 merge checkout