### PR TITLE
feat: add `verifyKeychain`/`verifyKeychainAdmin` to `ISignatureVerifier` (TIP-1049)

### DIFF
--- a/src/interfaces/ISignatureVerifier.sol
+++ b/src/interfaces/ISignatureVerifier.sol
@@ -22,4 +22,25 @@ interface ISignatureVerifier {
     /// @param signature The encoded signature (see Tempo Transaction spec for formats)
     /// @return True if the input address signed, false otherwise. Reverts on invalid signatures.
     function verify(address signer, bytes32 hash, bytes calldata signature) external view returns (bool);
+
+    /// @notice Verifies whether a keychain signature was produced by an active key (TIP-1049, T6).
+    /// @param account The expected embedded root account
+    /// @param hash The message hash that was signed
+    /// @param signature The encoded keychain signature
+    /// @dev Does not compare the inner signature type against the stored key type.
+    /// @dev Selector-gated to the T6 hardfork; reverts as an unknown selector before T6.
+    /// @return True if the keychain access key is active on account.
+    function verifyKeychain(address account, bytes32 hash, bytes calldata signature) external view returns (bool);
+
+    /// @notice Verifies whether a keychain signature was produced by a root or active admin key (TIP-1049, T6).
+    /// @param account The expected embedded root account
+    /// @param hash The message hash that was signed
+    /// @param signature The encoded keychain signature
+    /// @dev Does not compare the inner signature type against the stored key type.
+    /// @dev Selector-gated to the T6 hardfork; reverts as an unknown selector before T6.
+    /// @return True if the recovered key is account or an active admin key on account.
+    function verifyKeychainAdmin(address account, bytes32 hash, bytes calldata signature)
+        external
+        view
+        returns (bool);
 }

--- a/src/interfaces/ISignatureVerifier.sol
+++ b/src/interfaces/ISignatureVerifier.sol
@@ -39,8 +39,5 @@ interface ISignatureVerifier {
     /// @dev Does not compare the inner signature type against the stored key type.
     /// @dev Selector-gated to the T6 hardfork; reverts as an unknown selector before T6.
     /// @return True if the recovered key is account or an active admin key on account.
-    function verifyKeychainAdmin(address account, bytes32 hash, bytes calldata signature)
-        external
-        view
-        returns (bool);
+    function verifyKeychainAdmin(address account, bytes32 hash, bytes calldata signature) external view returns (bool);
 }


### PR DESCRIPTION
Adds the two TIP-1049 keychain verification methods to `ISignatureVerifier`, matching the T6 `SignatureVerifier` precompile (tempo v1.9.0):

- `verifyKeychain(address account, bytes32 hash, bytes signature) → bool`
- `verifyKeychainAdmin(address account, bytes32 hash, bytes signature) → bool`

Signatures match the node's canonical interface. These are T6-gated (revert as unknown selector before T6).