### PR TITLE
Update stablecoin DEX ABI

### DIFF
--- a/src/interfaces/IStablecoinDEX.sol
+++ b/src/interfaces/IStablecoinDEX.sol
@@ -58,6 +58,7 @@ interface IStablecoinDEX {
     error BelowMinimumOrderSize(uint128 amount);
     error InvalidBaseToken();
     error OrderNotStale();
+    error IndexAlreadySet();
 
     event OrderCancelled(uint128 indexed orderId);
     event OrderFilled(
@@ -110,6 +111,10 @@ interface IStablecoinDEX {
         view
         returns (address base, address quote, int16 bestBidTick, int16 bestAskTick);
 
+    function bookIndexForKey(bytes32 bookKey) external view returns (bool set, uint32 index);
+
+    function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
+
     function cancel(uint128 orderId) external;
 
     function cancelStaleOrder(uint128 orderId) external;
@@ -132,6 +137,8 @@ interface IStablecoinDEX {
         returns (uint128 orderId);
 
     function priceToTick(uint32 price) external pure returns (int16 tick);
+
+    function setBookIndex(uint32 index) external;
 
     function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn)
         external


### PR DESCRIPTION
## Summary
- add the T8 Stablecoin DEX book index accessors to `IStablecoinDEX`
- add the `IndexAlreadySet` error to match the precompile ABI

## Test
- `forge build`

Prompted by: @0xrusowsky