### PR TITLE
ci: fix Foundry nightly lint failures

### DIFF
--- a/src/sig/SignatureLib.sol
+++ b/src/sig/SignatureLib.sol
@@ -136,9 +136,14 @@ library SignatureLib {
         bytes32 rpIdHash = sha256(bytes(rpId));
         bytes memory authData = abi.encodePacked(rpIdHash, WEBAUTHN_FLAG_UP, bytes4(0));
         string memory challengeB64 = base64UrlEncode(abi.encodePacked(challenge));
-        bytes memory clientDataJSON =
-            abi.encodePacked('{"type":"webauthn.get","challenge":"', challengeB64, '","origin":"', origin, '"}');
-        return abi.encodePacked(authData, clientDataJSON);
+        bytes memory clientDataJSON = bytes.concat(
+            bytes('{"type":"webauthn.get","challenge":"'),
+            bytes(challengeB64),
+            bytes('","origin":"'),
+            bytes(origin),
+            bytes('"}')
+        );
+        return bytes.concat(authData, clientDataJSON);
     }
 
     /// @notice Computes the P256 message hash signed by a WebAuthn assertion.

--- a/src/tx/Eip1559TransactionLib.sol
+++ b/src/tx/Eip1559TransactionLib.sol
@@ -27,6 +27,9 @@ library Eip1559TransactionLib {
 
     /// @notice Creates a new EIP-1559 transaction with default values.
     function create() internal view returns (Eip1559Transaction memory tx_) {
+        require(block.chainid <= type(uint64).max, "chain ID exceeds uint64");
+        // Safe after the explicit range check above.
+        // forge-lint: disable-next-line(unsafe-typecast)
         tx_.chainId = uint64(block.chainid);
         tx_.gasLimit = 21000;
     }

--- a/src/tx/Eip7702TransactionLib.sol
+++ b/src/tx/Eip7702TransactionLib.sol
@@ -41,6 +41,9 @@ library Eip7702TransactionLib {
 
     /// @notice Creates a new EIP-7702 transaction with default values.
     function create() internal view returns (Eip7702Transaction memory tx_) {
+        require(block.chainid <= type(uint64).max, "chain ID exceeds uint64");
+        // Safe after the explicit range check above.
+        // forge-lint: disable-next-line(unsafe-typecast)
         tx_.chainId = uint64(block.chainid);
         tx_.gasLimit = 21000;
     }

--- a/src/tx/TxRlp.sol
+++ b/src/tx/TxRlp.sol
@@ -62,10 +62,10 @@ library TxRlp {
         if (len == 1 && uint8(str[0]) < 0x80) {
             return str;
         } else if (len <= 55) {
-            return abi.encodePacked(bytes1(uint8((0x80 + len) & 0xff)), str);
+            return bytes.concat(bytes1(uint8((0x80 + len) & 0xff)), str);
         } else {
             bytes memory lenBytes = encodeLength(len);
-            return abi.encodePacked(bytes1(uint8((0xb7 + lenBytes.length) & 0xff)), lenBytes, str);
+            return bytes.concat(bytes1(uint8((0xb7 + lenBytes.length) & 0xff)), lenBytes, str);
         }
     }
 
@@ -92,10 +92,10 @@ library TxRlp {
     function prependListPrefix(bytes memory payload) internal pure returns (bytes memory) {
         uint256 len = payload.length;
         if (len <= 55) {
-            return abi.encodePacked(bytes1(uint8((0xc0 + len) & 0xff)), payload);
+            return bytes.concat(bytes1(uint8((0xc0 + len) & 0xff)), payload);
         } else {
             bytes memory lenBytes = encodeLength(len);
-            return abi.encodePacked(bytes1(uint8((0xf7 + lenBytes.length) & 0xff)), lenBytes, payload);
+            return bytes.concat(bytes1(uint8((0xf7 + lenBytes.length) & 0xff)), lenBytes, payload);
         }
     }
 


### PR DESCRIPTION
Fixes CI against the latest Foundry nightly after foundry-rs/foundry#15707:

- uses `bytes.concat` for framed WebAuthn/RLP concatenation, avoiding conservative `abi.encodePacked` collision diagnostics on nightly without introducing nightly-only suppressions that stable Forge rejects
- validates `block.chainid` fits `uint64` before the intentional EIP-1559/EIP-7702 narrowing casts

Validated with stable Forge and latest nightly:
- `forge fmt --check`
- `forge build --skip test --deny warnings`
- `forge test`

Prompted by: @grandizzy