### PR TITLE
feat: add TIP-1091 zone factory interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ src
 │   ├── <a href="./src/interfaces/ITIP20.sol">ITIP20.sol</a>: TIP-20: Core Token Standard | <a href="https://docs.tempo.xyz/protocol/tip20/overview">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20/mod.rs">Implementation</a>
 │   ├── <a href="./src/interfaces/ITIP403Registry.sol">ITIP403Registry.sol</a>: TIP-403: Policy Registry System | <a href="https://docs.tempo.xyz/protocol/tip403/overview">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip403_registry/mod.rs">Implementation</a>
 │   ├── <a href="./src/interfaces/IValidatorConfig.sol">IValidatorConfig.sol</a>: Manage consensus validators | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/validator_config/mod.rs">Implementation</a>
-│   └── <a href="./src/interfaces/IValidatorConfigV2.sol">IValidatorConfigV2.sol</a>: Validator Config V2 (append-only) | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/validator_config_v2/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/IValidatorConfigV2.sol">IValidatorConfigV2.sol</a>: Validator Config V2 (append-only) | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/validator_config_v2/mod.rs">Implementation</a>
+│   ├── <a href="./src/interfaces/IZoneFactory.sol">IZoneFactory.sol</a>: TIP-1091 Native Zone Factory (T10+) | <a href="https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/contracts/src/precompiles/zone_factory.rs">Implementation</a>
+│   └── <a href="./src/interfaces/IZonePortal.sol">IZonePortal.sol</a>: TIP-1091 Native Zone Portal (T10+) | <a href="https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md">Docs</a> | <a href="https://github.com/tempoxyz/tempo/blob/main/crates/contracts/src/precompiles/zone_factory.rs">Implementation</a>
 └── <a href="./src/StdPrecompiles.sol">StdPrecompiles.sol</a>: Collection of precompiles and their interfaces on Tempo
 </pre>
 

--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -14,6 +14,7 @@ import {IStorageCredits} from "./interfaces/IStorageCredits.sol";
 import {IValidatorConfig} from "./interfaces/IValidatorConfig.sol";
 import {IValidatorConfigV2} from "./interfaces/IValidatorConfigV2.sol";
 import {INonce} from "./interfaces/INonce.sol";
+import {IZoneFactory} from "./interfaces/IZoneFactory.sol";
 
 /// @title Standard Precompiles Library for Tempo
 ///
@@ -32,6 +33,10 @@ library StdPrecompiles {
     address internal constant RECEIVE_POLICY_GUARD_ADDRESS = 0xB10C000000000000000000000000000000000000;
     address internal constant STORAGE_CREDITS_ADDRESS = 0x1060000000000000000000000000000000000000;
     address internal constant CURRENT_COMMITTEE_ADDRESS = 0xC077e00000000000000000000000000000000000;
+    address internal constant ZONE_FACTORY_ADDRESS = 0x5AF2000000000000000000000000000000000000;
+    address internal constant ZONE_PORTAL_IMPL_ADDRESS = 0x5AD1000000000000000000000000000000000000;
+    address internal constant ZONE_VERIFIER_ADDRESS = 0x5A56000000000000000000000000000000000000;
+    address internal constant ZONE_MESSENGER_ADDRESS = 0x5A4D000000000000000000000000000000000000;
 
     IFeeManager internal constant TIP_FEE_MANAGER = IFeeManager(TIP_FEE_MANAGER_ADDRESS);
     ITIP403Registry internal constant TIP403_REGISTRY = ITIP403Registry(TIP403_REGISTRY_ADDRESS);
@@ -46,4 +51,5 @@ library StdPrecompiles {
     IReceivePolicyGuard internal constant RECEIVE_POLICY_GUARD = IReceivePolicyGuard(RECEIVE_POLICY_GUARD_ADDRESS);
     IStorageCredits internal constant STORAGE_CREDITS = IStorageCredits(STORAGE_CREDITS_ADDRESS);
     ICurrentCommittee internal constant CURRENT_COMMITTEE = ICurrentCommittee(CURRENT_COMMITTEE_ADDRESS);
+    IZoneFactory internal constant ZONE_FACTORY = IZoneFactory(ZONE_FACTORY_ADDRESS);
 }

--- a/src/Tempo.sol
+++ b/src/Tempo.sol
@@ -17,6 +17,7 @@ import {ITIP403Registry} from "./interfaces/ITIP403Registry.sol";
 import {IReceivePolicyGuard} from "./interfaces/IReceivePolicyGuard.sol";
 import {IValidatorConfig} from "./interfaces/IValidatorConfig.sol";
 import {IValidatorConfigV2} from "./interfaces/IValidatorConfigV2.sol";
+import {IZoneFactory} from "./interfaces/IZoneFactory.sol";
 
 abstract contract Tempo {
     // Nonce precompile
@@ -38,6 +39,10 @@ abstract contract Tempo {
     // Current committee precompile
     ICurrentCommittee public constant currentCommittee = StdPrecompiles.CURRENT_COMMITTEE;
     address public constant CURRENT_COMMITTEE = StdPrecompiles.CURRENT_COMMITTEE_ADDRESS;
+
+    // Zone factory precompile
+    IZoneFactory public constant zoneFactory = StdPrecompiles.ZONE_FACTORY;
+    address public constant ZONE_FACTORY = StdPrecompiles.ZONE_FACTORY_ADDRESS;
 
     // Fee manager precompile
     IFeeManager public constant feeAMM = StdPrecompiles.TIP_FEE_MANAGER;

--- a/src/interfaces/IZoneFactory.sol
+++ b/src/interfaces/IZoneFactory.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/// @title Zone Factory Precompile Interface (TIP-1091)
+/// @notice Deployed at `StdPrecompiles.ZONE_FACTORY_ADDRESS` from Hardfork T10.
+interface IZoneFactory {
+    /// @notice Zone metadata recorded by the native factory.
+    struct ZoneInfo {
+        uint32 zoneId;
+        address portal;
+        bool accessMode;
+        bool gatewayMode;
+        address admin;
+        address[] sequencers;
+        uint8 threshold;
+        address verifier;
+        string rpcUrl;
+    }
+
+    /// @notice Parameters required to deploy and initialize a new Zone.
+    struct CreateZoneParams {
+        address initialToken;
+        bool accessMode;
+        bool gatewayMode;
+        address[] allowedAccounts;
+        address[] zoneGateways;
+        address admin;
+        address[] sequencers;
+        uint8 threshold;
+        string rpcUrl;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    event ZoneCreated(
+        uint32 indexed zoneId,
+        address indexed portal,
+        address initialToken,
+        bool accessMode,
+        bool gatewayMode,
+        address admin,
+        address[] sequencers,
+        uint8 threshold,
+        address verifier
+    );
+
+    error InvalidToken();
+    error TokenTransferPolicyNotSet();
+    error InvalidClosedLoopConfig();
+    error NotOwner();
+    error InvalidAdmin();
+    error InvalidSequencerSet();
+    error AlreadyInitialized();
+    error TokenMetadataTooLong();
+
+    function owner() external view returns (address);
+    function transferOwnership(address newOwner) external;
+    function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
+    function nextZoneId() external view returns (uint32);
+    function zones(uint32 id) external view returns (ZoneInfo memory info);
+    function isZonePortal(address portal) external view returns (bool);
+}

--- a/src/interfaces/IZonePortal.sol
+++ b/src/interfaces/IZonePortal.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/// @title Zone Portal Interface (TIP-1091)
+/// @notice Minimal portal interface for Zone state management and event subscriptions.
+interface IZonePortal {
+    enum Role {
+        None,
+        Sequencer,
+        Account,
+        CallbackGateway,
+        PauseGuardian
+    }
+
+    enum Capability {
+        PausePortal,
+        AccessPolicy
+    }
+
+    event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers);
+    event TokenEnabled(address indexed token, string name, string symbol, string currency);
+    event RoleUpdated(address indexed account, Role prev, Role next);
+    event EnforcementModesUpdated(bool accessMode, bool gatewayMode);
+    event LeaderUpdated(
+        address indexed previousLeader,
+        address indexed newLeader,
+        uint64 indexed leaderEpoch,
+        uint64 leaderActivationTempoBlock
+    );
+}

--- a/test/ZoneFactory.t.sol
+++ b/test/ZoneFactory.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+import {StdPrecompiles} from "../src/StdPrecompiles.sol";
+import {Tempo} from "../src/Tempo.sol";
+import {IZoneFactory} from "../src/interfaces/IZoneFactory.sol";
+import {IZonePortal} from "../src/interfaces/IZonePortal.sol";
+
+contract ZoneFactoryExportsTest is Tempo {
+    address internal constant EXPECTED_ZONE_FACTORY_ADDRESS = 0x5AF2000000000000000000000000000000000000;
+    address internal constant EXPECTED_ZONE_PORTAL_IMPL_ADDRESS = 0x5AD1000000000000000000000000000000000000;
+    address internal constant EXPECTED_ZONE_VERIFIER_ADDRESS = 0x5A56000000000000000000000000000000000000;
+    address internal constant EXPECTED_ZONE_MESSENGER_ADDRESS = 0x5A4D000000000000000000000000000000000000;
+
+    function testAddressExports() public pure {
+        require(StdPrecompiles.ZONE_FACTORY_ADDRESS == EXPECTED_ZONE_FACTORY_ADDRESS, "StdPrecompiles zone factory address");
+        require(StdPrecompiles.ZONE_PORTAL_IMPL_ADDRESS == EXPECTED_ZONE_PORTAL_IMPL_ADDRESS, "StdPrecompiles portal impl address");
+        require(StdPrecompiles.ZONE_VERIFIER_ADDRESS == EXPECTED_ZONE_VERIFIER_ADDRESS, "StdPrecompiles verifier address");
+        require(StdPrecompiles.ZONE_MESSENGER_ADDRESS == EXPECTED_ZONE_MESSENGER_ADDRESS, "StdPrecompiles messenger address");
+        require(ZONE_FACTORY == EXPECTED_ZONE_FACTORY_ADDRESS, "Tempo zone factory address");
+    }
+
+    function testTypedExports() public pure {
+        require(address(StdPrecompiles.ZONE_FACTORY) == EXPECTED_ZONE_FACTORY_ADDRESS, "StdPrecompiles typed export");
+        require(address(zoneFactory) == EXPECTED_ZONE_FACTORY_ADDRESS, "Tempo typed export");
+    }
+
+    function testAbiSelectors() public pure {
+        require(IZoneFactory.owner.selector == bytes4(keccak256("owner()")), "owner selector");
+        require(IZoneFactory.transferOwnership.selector == bytes4(keccak256("transferOwnership(address)")), "transferOwnership selector");
+        require(IZoneFactory.nextZoneId.selector == bytes4(keccak256("nextZoneId()")), "nextZoneId selector");
+        require(IZoneFactory.zones.selector == bytes4(keccak256("zones(uint32)")), "zones selector");
+        require(IZoneFactory.isZonePortal.selector == bytes4(keccak256("isZonePortal(address)")), "isZonePortal selector");
+
+        require(IZoneFactory.InvalidToken.selector == bytes4(keccak256("InvalidToken()")), "InvalidToken selector");
+        require(IZoneFactory.TokenTransferPolicyNotSet.selector == bytes4(keccak256("TokenTransferPolicyNotSet()")), "TokenTransferPolicyNotSet selector");
+        require(IZoneFactory.InvalidClosedLoopConfig.selector == bytes4(keccak256("InvalidClosedLoopConfig()")), "InvalidClosedLoopConfig selector");
+        require(IZoneFactory.NotOwner.selector == bytes4(keccak256("NotOwner()")), "NotOwner selector");
+        require(IZoneFactory.InvalidAdmin.selector == bytes4(keccak256("InvalidAdmin()")), "InvalidAdmin selector");
+        require(IZoneFactory.InvalidSequencerSet.selector == bytes4(keccak256("InvalidSequencerSet()")), "InvalidSequencerSet selector");
+        require(IZoneFactory.AlreadyInitialized.selector == bytes4(keccak256("AlreadyInitialized()")), "AlreadyInitialized selector");
+        require(IZoneFactory.TokenMetadataTooLong.selector == bytes4(keccak256("TokenMetadataTooLong()")), "TokenMetadataTooLong selector");
+    }
+}


### PR DESCRIPTION
Adds Solidity interfaces, address constants, and selector tests for the TIP-1091 Native Zone Factory and Zone Portal precompiles introduced in the T10 hardfork.

### Changes
- Adds `IZoneFactory.sol` and `IZonePortal.sol` interfaces matching the native precompile ABI.
- Exposes `ZONE_FACTORY_ADDRESS`, `ZONE_PORTAL_IMPL_ADDRESS`, `ZONE_VERIFIER_ADDRESS`, and `ZONE_MESSENGER_ADDRESS` in `StdPrecompiles`.
- Exposes `zoneFactory` and `ZONE_FACTORY` in `Tempo.sol`.
- Adds `ZoneFactory.t.sol` export and selector tests.
- Updates README interfaces list.