### PR TITLE
fix: align validator getter names

### DIFF
--- a/src/interfaces/IFeeAMM.sol
+++ b/src/interfaces/IFeeAMM.sol
@@ -60,7 +60,7 @@ interface IFeeAMM {
 
     function getPoolId(address userToken, address validatorToken) external pure returns (bytes32);
 
-    function liquidityBalances(bytes32, address) external view returns (uint256);
+    function liquidityBalances(bytes32 poolId, address user) external view returns (uint256);
 
     function mint(address userToken, address validatorToken, uint256 amountValidatorToken, address to)
         external

--- a/src/interfaces/IFeeAMM.sol
+++ b/src/interfaces/IFeeAMM.sol
@@ -66,11 +66,11 @@ interface IFeeAMM {
         external
         returns (uint256 liquidity);
 
-    function pools(bytes32) external view returns (uint128 reserveUserToken, uint128 reserveValidatorToken);
+    function pools(bytes32 poolId) external view returns (uint128 reserveUserToken, uint128 reserveValidatorToken);
 
     function rebalanceSwap(address userToken, address validatorToken, uint256 amountOut, address to)
         external
         returns (uint256 amountIn);
 
-    function totalSupply(bytes32) external view returns (uint256);
+    function totalSupply(bytes32 poolId) external view returns (uint256);
 }

--- a/src/interfaces/IStablecoinDEX.sol
+++ b/src/interfaces/IStablecoinDEX.sol
@@ -111,9 +111,9 @@ interface IStablecoinDEX {
         view
         returns (address base, address quote, int16 bestBidTick, int16 bestAskTick);
 
-    function bookIndexForKey(bytes32 key) external view returns (bool exists, uint32 index);
+    function bookIndexForKey(bytes32 bookKey) external view returns (bool exists, uint32 index);
 
-    function bookKeyForIndex(uint32 index) external view returns (bytes32 key);
+    function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
 
     function cancel(uint128 orderId) external;
 

--- a/src/interfaces/ITIP20.sol
+++ b/src/interfaces/ITIP20.sol
@@ -183,7 +183,7 @@ interface ITIP20 is ITIP20RolesAuthErr {
 
     function setNextQuoteToken(ITIP20 newQuoteToken) external;
 
-    function setRewardRecipient(address newRewardRecipient) external;
+    function setRewardRecipient(address recipient) external;
 
     function setSupplyCap(uint256 newSupplyCap) external;
 
@@ -233,7 +233,7 @@ interface ITIP20 is ITIP20RolesAuthErr {
     /// @notice Unpauses the contract, allowing transfers and other operations to resume.
     function unpause() external;
 
-    function userRewardInfo(address)
+    function userRewardInfo(address account)
         external
         view
         returns (address rewardRecipient, uint256 rewardPerToken, uint256 rewardBalance);

--- a/src/interfaces/IValidatorConfig.sol
+++ b/src/interfaces/IValidatorConfig.sol
@@ -35,7 +35,7 @@ interface IValidatorConfig {
     /// @param publicKey The validator's communication public key
     /// @param active Whether the validator is active in consensus
     /// @param index The validator's index in the validators array
-    /// @param validatorAddress The validator's address
+    /// @param validator The validator's address
     /// @param inboundAddress Address where other validators can connect to this validator (format: `<hostname|ip>:<port>`)
     /// @param outboundAddress IP address for firewall whitelisting by other validators (format: `<ip>:<port>`)
     struct Validator {
@@ -56,17 +56,17 @@ interface IValidatorConfig {
     /// @return publicKey The validator's communication public key
     /// @return active Whether the validator is active
     /// @return index The validator's index
-    /// @return addr The validator's address
+    /// @return validatorAddress The validator's address
     /// @return inboundAddress The validator's inbound address
     /// @return outboundAddress The validator's outbound address
-    function validators(address validatorAddress)
+    function validators(address validator)
         external
         view
         returns (
             bytes32 publicKey,
             bool active,
             uint64 index,
-            address addr,
+            address validatorAddress,
             string memory inboundAddress,
             string memory outboundAddress
         );


### PR DESCRIPTION
Aligns the `validators` getter input/output names with the `Validator` struct while avoiding Solidity’s duplicate-identifier restriction. This allows strict ABI comparison to normalize the struct return and compare every inner component name.

Prompted by: @0xalpharush