### PR TITLE
feat: add TIP-1034 TIP-20 channel reserve interface

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -9,6 +9,7 @@ import {ISignatureVerifier} from "./interfaces/ISignatureVerifier.sol";
 import {ITIP403Registry} from "./interfaces/ITIP403Registry.sol";
 import {IReceivePolicyGuard} from "./interfaces/IReceivePolicyGuard.sol";
 import {ITIP20Factory} from "./interfaces/ITIP20Factory.sol";
+import {ITIP20ChannelReserve} from "./interfaces/ITIP20ChannelReserve.sol";
 import {IStablecoinDEX} from "./interfaces/IStablecoinDEX.sol";
 import {IStorageCredits} from "./interfaces/IStorageCredits.sol";
 import {IValidatorConfig} from "./interfaces/IValidatorConfig.sol";
@@ -29,6 +30,7 @@ library StdPrecompiles {
     address internal constant VALIDATOR_CONFIG_V2_ADDRESS = 0xCcCCCCcC00000000000000000000000000000001;
     address internal constant ADDRESS_REGISTRY_ADDRESS = 0xfDC0000000000000000000000000000000000000;
     address internal constant SIGNATURE_VERIFIER_ADDRESS = 0x5165300000000000000000000000000000000000;
+    address internal constant TIP20_CHANNEL_RESERVE_ADDRESS = 0x4d50500000000000000000000000000000000000;
     address internal constant RECEIVE_POLICY_GUARD_ADDRESS = 0xB10C000000000000000000000000000000000000;
     address internal constant STORAGE_CREDITS_ADDRESS = 0x1060000000000000000000000000000000000000;
     address internal constant CURRENT_COMMITTEE_ADDRESS = 0xC077e00000000000000000000000000000000000;
@@ -43,6 +45,7 @@ library StdPrecompiles {
     IValidatorConfigV2 internal constant VALIDATOR_CONFIG_V2 = IValidatorConfigV2(VALIDATOR_CONFIG_V2_ADDRESS);
     IAddressRegistry internal constant ADDRESS_REGISTRY = IAddressRegistry(ADDRESS_REGISTRY_ADDRESS);
     ISignatureVerifier internal constant SIGNATURE_VERIFIER = ISignatureVerifier(SIGNATURE_VERIFIER_ADDRESS);
+    ITIP20ChannelReserve internal constant TIP20_CHANNEL_RESERVE = ITIP20ChannelReserve(TIP20_CHANNEL_RESERVE_ADDRESS);
     IReceivePolicyGuard internal constant RECEIVE_POLICY_GUARD = IReceivePolicyGuard(RECEIVE_POLICY_GUARD_ADDRESS);
     IStorageCredits internal constant STORAGE_CREDITS = IStorageCredits(STORAGE_CREDITS_ADDRESS);
     ICurrentCommittee internal constant CURRENT_COMMITTEE = ICurrentCommittee(CURRENT_COMMITTEE_ADDRESS);

--- a/src/Tempo.sol
+++ b/src/Tempo.sol
@@ -12,6 +12,7 @@ import {ISignatureVerifier} from "./interfaces/ISignatureVerifier.sol";
 import {IStablecoinDEX} from "./interfaces/IStablecoinDEX.sol";
 import {IStorageCredits} from "./interfaces/IStorageCredits.sol";
 import {ITIP20} from "./interfaces/ITIP20.sol";
+import {ITIP20ChannelReserve} from "./interfaces/ITIP20ChannelReserve.sol";
 import {ITIP20Factory} from "./interfaces/ITIP20Factory.sol";
 import {ITIP403Registry} from "./interfaces/ITIP403Registry.sol";
 import {IReceivePolicyGuard} from "./interfaces/IReceivePolicyGuard.sol";
@@ -70,6 +71,10 @@ abstract contract Tempo {
     // TIP-20 factory precompile
     ITIP20Factory public constant tip20Factory = StdPrecompiles.TIP20_FACTORY;
     address public constant TIP20_FACTORY = StdPrecompiles.TIP20_FACTORY_ADDRESS;
+
+    // TIP-20 channel reserve precompile
+    ITIP20ChannelReserve public constant tip20ChannelReserve = StdPrecompiles.TIP20_CHANNEL_RESERVE;
+    address public constant TIP20_CHANNEL_RESERVE = StdPrecompiles.TIP20_CHANNEL_RESERVE_ADDRESS;
 
     // pathUSD is just a TIP20 at a special address (0x20C0...) with token_id=0
     ITIP20 public constant pathUSD = StdTokens.PATH_USD;

--- a/src/interfaces/ITIP20ChannelReserve.sol
+++ b/src/interfaces/ITIP20ChannelReserve.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/// @title ITIP20ChannelReserve
+/// @notice Interface for the TIP-1034 native TIP-20 Channel Reserve precompile on Tempo.
+/// @dev Precompile address: 0x4d50500000000000000000000000000000000000 (Activated in Hardfork T5)
+interface ITIP20ChannelReserve {
+    /// @notice Immutable channel identity supplied to all descriptor-based methods.
+    struct ChannelDescriptor {
+        address payer;
+        address payee;
+        address operator;
+        address token;
+        bytes32 salt;
+        address authorizedSigner;
+        bytes32 expiringNonceHash;
+    }
+
+    /// @notice Mutable channel state packed into one native storage slot.
+    struct ChannelState {
+        uint96 settled;
+        uint96 deposit;
+        uint32 closeRequestedAt;
+    }
+
+    /// @notice Full descriptor plus current state.
+    struct Channel {
+        ChannelDescriptor descriptor;
+        ChannelState state;
+    }
+
+    /// @notice Delay between payer `requestClose` and `withdraw` (15 minutes).
+    function CLOSE_GRACE_PERIOD() external view returns (uint64);
+
+    /// @notice EIP-712 type hash for `Voucher(bytes32 channelId,uint96 cumulativeAmount)`.
+    function VOUCHER_TYPEHASH() external view returns (bytes32);
+
+    /// @notice Opens a channel and pulls `deposit` TIP-20 units from `msg.sender`.
+    function open(
+        address payee,
+        address operator,
+        address token,
+        uint96 deposit,
+        bytes32 salt,
+        address authorizedSigner
+    ) external returns (bytes32 channelId);
+
+    /// @notice Pays the unsettled delta up to `cumulativeAmount` using a valid voucher.
+    function settle(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Adds deposit to a channel and cancels any pending close request.
+    function topUp(
+        ChannelDescriptor calldata descriptor,
+        uint96 additionalDeposit
+    ) external;
+
+    /// @notice Closes the channel from the payee/operator side and refunds uncaptured deposit.
+    function close(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        uint96 captureAmount,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Starts the payer withdrawal timer.
+    function requestClose(ChannelDescriptor calldata descriptor) external;
+
+    /// @notice Withdraws the payer refund after the close grace period has elapsed.
+    function withdraw(ChannelDescriptor calldata descriptor) external;
+
+    /// @notice Returns the descriptor and state for a channel.
+    function getChannel(ChannelDescriptor calldata descriptor) external view returns (Channel memory);
+
+    /// @notice Returns the state for `channelId`, or the zero state when absent.
+    function getChannelState(bytes32 channelId) external view returns (ChannelState memory);
+
+    /// @notice Returns states for `channelIds` in order.
+    function getChannelStatesBatch(bytes32[] calldata channelIds) external view returns (ChannelState[] memory);
+
+    /// @notice Computes the canonical channel id for a descriptor.
+    function computeChannelId(
+        address payer,
+        address payee,
+        address operator,
+        address token,
+        bytes32 salt,
+        address authorizedSigner,
+        bytes32 expiringNonceHash
+    ) external view returns (bytes32);
+
+    /// @notice Computes the EIP-712 digest signed by the payer or authorized signer.
+    function getVoucherDigest(bytes32 channelId, uint96 cumulativeAmount) external view returns (bytes32);
+
+    /// @notice Returns the EIP-712 domain separator for the current chain.
+    function domainSeparator() external view returns (bytes32);
+
+    /// @notice Returns the number of reusable channel storage credits owned by `payer`.
+    function storageCredits(address payer) external view returns (uint64 credits);
+
+    /// @notice Emitted after a channel is opened and funded.
+    event ChannelOpened(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        address operator,
+        address token,
+        address authorizedSigner,
+        bytes32 salt,
+        bytes32 expiringNonceHash,
+        uint96 deposit
+    );
+
+    /// @notice Emitted after voucher settlement pays a delta to the payee.
+    event Settled(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint96 cumulativeAmount,
+        uint96 deltaPaid,
+        uint96 newSettled
+    );
+
+    /// @notice Emitted after channel deposit changes or a close request is cancelled by top-up.
+    event TopUp(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint96 additionalDeposit,
+        uint96 newDeposit
+    );
+
+    /// @notice Emitted when the payer starts the close grace timer.
+    event CloseRequested(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint256 closeGraceEnd
+    );
+
+    /// @notice Emitted when a channel is deleted by payee close or payer withdraw.
+    event ChannelClosed(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint96 settledToPayee,
+        uint96 refundedToPayer
+    );
+
+    /// @notice Emitted when top-up clears a pending close request.
+    event CloseRequestCancelled(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee
+    );
+
+    error ChannelAlreadyExists();
+    error ChannelNotFound();
+    error NotPayer();
+    error NotPayeeOrOperator();
+    error InvalidPayee();
+    error ZeroDeposit();
+    error ExpiringNonceHashNotSet();
+    error InvalidSignature();
+    error AmountExceedsDeposit();
+    error AmountNotIncreasing();
+    error CaptureAmountInvalid();
+    error CloseNotReady();
+    error DepositOverflow();
+}

--- a/test/TIP20ChannelReserve.t.sol
+++ b/test/TIP20ChannelReserve.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+import {StdPrecompiles} from "../src/StdPrecompiles.sol";
+import {Tempo} from "../src/Tempo.sol";
+import {ITIP20ChannelReserve} from "../src/interfaces/ITIP20ChannelReserve.sol";
+
+contract TIP20ChannelReserveExportsTest is Tempo {
+    address internal constant EXPECTED_TIP20_CHANNEL_RESERVE_ADDRESS = 0x4d50500000000000000000000000000000000000;
+
+    function testAddressExports() public pure {
+        require(
+            StdPrecompiles.TIP20_CHANNEL_RESERVE_ADDRESS == EXPECTED_TIP20_CHANNEL_RESERVE_ADDRESS,
+            "StdPrecompiles tip20 channel reserve address mismatch"
+        );
+        require(
+            TIP20_CHANNEL_RESERVE == EXPECTED_TIP20_CHANNEL_RESERVE_ADDRESS,
+            "Tempo tip20 channel reserve address mismatch"
+        );
+    }
+
+    function testTypedExports() public pure {
+        require(
+            address(StdPrecompiles.TIP20_CHANNEL_RESERVE) == EXPECTED_TIP20_CHANNEL_RESERVE_ADDRESS,
+            "StdPrecompiles typed export mismatch"
+        );
+        require(
+            address(tip20ChannelReserve) == EXPECTED_TIP20_CHANNEL_RESERVE_ADDRESS,
+            "Tempo typed export mismatch"
+        );
+    }
+
+    function testFunctionSelectors() public pure {
+        require(
+            ITIP20ChannelReserve.CLOSE_GRACE_PERIOD.selector == bytes4(keccak256("CLOSE_GRACE_PERIOD()")),
+            "CLOSE_GRACE_PERIOD selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.VOUCHER_TYPEHASH.selector == bytes4(keccak256("VOUCHER_TYPEHASH()")),
+            "VOUCHER_TYPEHASH selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.open.selector == bytes4(keccak256("open(address,address,address,uint96,bytes32,address)")),
+            "open selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.settle.selector == bytes4(keccak256("settle((address,address,address,address,bytes32,address,bytes32),uint96,bytes)")),
+            "settle selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.topUp.selector == bytes4(keccak256("topUp((address,address,address,address,bytes32,address,bytes32),uint96)")),
+            "topUp selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.close.selector == bytes4(keccak256("close((address,address,address,address,bytes32,address,bytes32),uint96,uint96,bytes)")),
+            "close selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.requestClose.selector == bytes4(keccak256("requestClose((address,address,address,address,bytes32,address,bytes32))")),
+            "requestClose selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.withdraw.selector == bytes4(keccak256("withdraw((address,address,address,address,bytes32,address,bytes32))")),
+            "withdraw selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.getChannel.selector == bytes4(keccak256("getChannel((address,address,address,address,bytes32,address,bytes32))")),
+            "getChannel selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.getChannelState.selector == bytes4(keccak256("getChannelState(bytes32)")),
+            "getChannelState selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.getChannelStatesBatch.selector == bytes4(keccak256("getChannelStatesBatch(bytes32[])")),
+            "getChannelStatesBatch selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.computeChannelId.selector == bytes4(keccak256("computeChannelId(address,address,address,address,bytes32,address,bytes32)")),
+            "computeChannelId selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.getVoucherDigest.selector == bytes4(keccak256("getVoucherDigest(bytes32,uint96)")),
+            "getVoucherDigest selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.domainSeparator.selector == bytes4(keccak256("domainSeparator()")),
+            "domainSeparator selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.storageCredits.selector == bytes4(keccak256("storageCredits(address)")),
+            "storageCredits selector mismatch"
+        );
+    }
+
+    function testErrorSelectors() public pure {
+        require(
+            ITIP20ChannelReserve.ChannelAlreadyExists.selector == bytes4(keccak256("ChannelAlreadyExists()")),
+            "ChannelAlreadyExists selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.ChannelNotFound.selector == bytes4(keccak256("ChannelNotFound()")),
+            "ChannelNotFound selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.NotPayer.selector == bytes4(keccak256("NotPayer()")),
+            "NotPayer selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.NotPayeeOrOperator.selector == bytes4(keccak256("NotPayeeOrOperator()")),
+            "NotPayeeOrOperator selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.InvalidPayee.selector == bytes4(keccak256("InvalidPayee()")),
+            "InvalidPayee selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.ZeroDeposit.selector == bytes4(keccak256("ZeroDeposit()")),
+            "ZeroDeposit selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.ExpiringNonceHashNotSet.selector == bytes4(keccak256("ExpiringNonceHashNotSet()")),
+            "ExpiringNonceHashNotSet selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.InvalidSignature.selector == bytes4(keccak256("InvalidSignature()")),
+            "InvalidSignature selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.AmountExceedsDeposit.selector == bytes4(keccak256("AmountExceedsDeposit()")),
+            "AmountExceedsDeposit selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.AmountNotIncreasing.selector == bytes4(keccak256("AmountNotIncreasing()")),
+            "AmountNotIncreasing selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.CaptureAmountInvalid.selector == bytes4(keccak256("CaptureAmountInvalid()")),
+            "CaptureAmountInvalid selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.CloseNotReady.selector == bytes4(keccak256("CloseNotReady()")),
+            "CloseNotReady selector mismatch"
+        );
+        require(
+            ITIP20ChannelReserve.DepositOverflow.selector == bytes4(keccak256("DepositOverflow()")),
+            "DepositOverflow selector mismatch"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the standard Solidity interface, precompile constants, and unit tests for the **TIP-1034 TIP-20 Channel Reserve Precompile** (`0x4d50500000000000000000000000000000000000`), introduced in Tempo Hardfork T5.

The TIP-20 Channel Reserve serves as the foundational on-chain primitive for the Machine Payments Protocol (MPP), locking payer deposits, settling increasing cumulative EIP-712 vouchers, and managing unilateral close grace timers.

## Changes

1. **`src/interfaces/ITIP20ChannelReserve.sol`**:
   - Declares `ChannelDescriptor`, `ChannelState`, and `Channel` structs.
   - Declares all channel lifecycle methods: `open`, `settle`, `topUp`, `close`, `requestClose`, `withdraw`.
   - Declares getters: `getChannel`, `getChannelState`, `getChannelStatesBatch`, `computeChannelId`, `getVoucherDigest`, `domainSeparator`, `storageCredits`.
   - Declares events and custom errors.

2. **`src/StdPrecompiles.sol` & `src/Tempo.sol`**:
   - Added `TIP20_CHANNEL_RESERVE_ADDRESS = 0x4d50500000000000000000000000000000000000`.
   - Added typed `TIP20_CHANNEL_RESERVE` and `Tempo.tip20ChannelReserve` export.

3. **`test/TIP20ChannelReserve.t.sol`**:
   - Comprehensive test suite asserting precompile address exports, typed exports, 15 function selectors, and 13 custom error selectors against canonical hashes.

## Verification

```bash
forge test
All tests passing across all suites.