### PR TITLE
ci: install Foundry via gh-actions setup-foundry (attested releases)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+      - uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab # main
         with:
           version: ${{ matrix.toolchain }}
       - run: forge --version
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+      - uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab # main
         with:
           version: ${{ matrix.toolchain }}
       - run: forge --version
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+      - uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab # main
       - run: forge --version
       - run: forge fmt --check
 


### PR DESCRIPTION
## Why

`tempoxyz/gh-actions` now ships a first-party `setup-foundry` (tempoxyz/gh-actions#82) that installs Foundry directly from GitHub releases and verifies each tarball's SLSA provenance with `gh attestation verify` (built by `foundry-rs/foundry`'s release workflow at the resolved tag, or `master` for nightlies), on top of the `.sha256` check. `foundry-rs/foundry-toolchain` runs `foundryup` and verifies nothing it downloads. Switching also removes a third-party action ahead of the org-only actions policy.

## What changes at run time

- `version: nightly` resolves to the newest `nightly-<commit>` build, which is the same content the rolling `nightly` tag mirrors, but attested. `stable` resolves to the newest `vX.Y.Z` release. Explicit tags work as before.
- forge, cast, anvil and chisel are installed under `RUNNER_TEMP` and added to `PATH`; `foundryup` itself is not installed (nothing here referenced it).
- The RPC response cache (`~/.foundry/cache`) is kept with the same `cache`, `cache-key` and `cache-restore-keys` inputs and key scheme; the first run after merge is a cache miss because the key prefix changed from `linux-` to `Linux-`.
- Inputs are unchanged, so no `with:` blocks needed editing.

Pinned to gh-actions `main` at `16356ec5` (the commit that landed the verifying installer). `actionlint` and `zizmor` report the same results as before on the changed files.

The `${{ matrix.toolchain }}` values continue to work: `stable`, `nightly`, `vX.Y.Z` and `nightly-<commit>` are all accepted.

Files: .github/workflows/ci.yml