### PR TITLE
ci: switch to first-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0
+      - uses: tempoxyz/gh-actions/actions/typos@ab45d76f6e7420a094281a22aee1973ecc0754f8
 
   ci-success:
     runs-on: ubuntu-latest
@@ -129,6 +129,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: tempoxyz/gh-actions/actions/check-needs@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

Switches this repository's workflows from third-party actions to the equivalent first-party composites in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions), pinned to a full commit SHA. Inputs and outputs are unchanged unless noted below.

| Before | After |
| --- | --- |
| `crate-ci/typos` | [`tempoxyz/gh-actions/actions/typos`](https://github.com/tempoxyz/gh-actions/tree/ab45d76f6e7420a094281a22aee1973ecc0754f8/actions/typos) |
| `re-actors/alls-green` | [`tempoxyz/gh-actions/actions/check-needs`](https://github.com/tempoxyz/gh-actions/tree/ab45d76f6e7420a094281a22aee1973ecc0754f8/actions/check-needs) |

## Notes

- **typos**: the pinned typos release is verified with `gh release verify-asset` before use; the repository's own typos config is still auto-discovered.

## Verification

- `actionlint` and `zizmor` (regular persona, offline) report no new findings after the change (actionlint 2 -> 2, zizmor 0 -> 0).
